### PR TITLE
Fix/stable fixes

### DIFF
--- a/jumpstarter/README.md
+++ b/jumpstarter/README.md
@@ -38,11 +38,6 @@ tee config.toml <<EOF
 append = "console=ttyTCU0 pd_ignore_unused"
 
 [[customizations.user]]
-name = "${JETSON_USERNAME}"
-password = "${JETSON_PASSWORD}"
-groups = ["video", "wheel"]
-
-[[customizations.user]]
 name = "root"
 password = "${JETSON_PASSWORD}"
 key = "$(cat ~/.ssh/*.pub)"
@@ -109,13 +104,6 @@ Inside the Jumpstarter shell:
 
 ```bash
 j storage flash --compression xz ./output/image/disk.raw.xz
-j storage dut # witch storage to the Jetson so it can boot from it
-j power cycle # power on the device
-j serial start-console # verify boot (exit: Ctrl+B x3)
-# On the console's machine itself
-# login via root, for password- what you configured in config.toml
-/usr/libexec/bootc-generic-growpart # expand the root partition
-exit # exit from the console , back to the Jumpstarter Shell
 ```
 
 ---
@@ -124,23 +112,7 @@ exit # exit from the console , back to the Jumpstarter Shell
 
 Two options after flashing:
 
-### Option A: Run Directly (outside Jumpstarter shell)
-
-Keep the Jumpstarter shell open in one terminal. In another terminal:
-
-```bash
-export JETSON_HOST=<device-hostname>
-export JETSON_USERNAME=root
-export JETSON_PASSWORD="your-password"
-
-cd qe-rhel-jetson
-source .venv/bin/activate # In case you already created py interpreter
-pytest tests_suites/
-```
-
-> See [tests_suites/README.md](../tests_suites/README.md) for test configuration details.
-
-### Option B: Run via wrapper.py (automated, recommended)
+### Option A: Run via wrapper.py (automated, recommended)
 
 The wrapper automates: power cycle → enable SSH → growpart → run pytest.
 
@@ -158,6 +130,34 @@ jmp shell --lease <LEASE_NAME> -- python jumpstarter/wrapper.py pytest tests_sui
 ```bash
 exit    # from the Jumpstarter shell
 ```
+
+### Option B: Run Directly (outside Jumpstarter shell)
+
+In the Jumpstarter shell:
+
+```bash
+j storage dut # witch storage to the Jetson so it can boot from it
+j power cycle # power on the device
+j serial start-console # verify boot (exit: Ctrl+B x3)
+# On the console's machine itself
+# login via root, for password- what you configured in config.toml
+/usr/libexec/bootc-generic-growpart # expand the root partition
+exit # exit from the console , back to the Jumpstarter Shell
+```
+
+Keep the Jumpstarter shell open in one terminal. In another terminal:
+
+```bash
+export JETSON_HOST=<device-hostname>
+export JETSON_USERNAME=root
+export JETSON_PASSWORD="your-password"
+
+cd qe-rhel-jetson
+source .venv/bin/activate # In case you already created py interpreter
+pytest tests_suites/
+```
+
+> See [tests_suites/README.md](../tests_suites/README.md) for test configuration details.
 
 ---
 

--- a/jumpstarter/README.md
+++ b/jumpstarter/README.md
@@ -35,7 +35,7 @@ podman system connection default podman-machine-default-root
 ```bash
 tee config.toml <<EOF
 [customizations.kernel]
-append = "console=ttyTCU0"
+append = "console=ttyTCU0 pd_ignore_unused"
 
 [[customizations.user]]
 name = "${JETSON_USERNAME}"
@@ -52,6 +52,10 @@ EOF
 
 > **Note:** The `key` field must contain the **public key content** (not a file path).
 > `$(cat ~/.ssh/*.pub)` expands to your actual public key string.
+
+> **Why `pd_ignore_unused`?** Display tests need `nvidia_drm` loaded, which on RHEL 9.7
+> can cause a kernel hang without this flag. Baking it into the image avoids a reboot
+> during testing — important because Jumpstarter's SSH tunnel can't survive a device reboot.
 
 ### Pull and Build
 

--- a/jumpstarter/README.md
+++ b/jumpstarter/README.md
@@ -112,7 +112,10 @@ j storage flash --compression xz ./output/image/disk.raw.xz
 j storage dut # witch storage to the Jetson so it can boot from it
 j power cycle # power on the device
 j serial start-console # verify boot (exit: Ctrl+B x3)
-ssh root@<device> /usr/libexec/bootc-generic-growpart # expand the root partition
+# On the console's machine itself
+# login via root, for password- what you configured in config.toml
+/usr/libexec/bootc-generic-growpart # expand the root partition
+exit # exit from the console , back to the Jumpstarter Shell
 ```
 
 ---

--- a/jumpstarter/wrapper.py
+++ b/jumpstarter/wrapper.py
@@ -69,6 +69,7 @@ with env() as client:
         with TcpPortforwardAdapter(client=client.ssh.tcp) as addr:
             os.environ["JETSON_HOST"] = addr[0]
             os.environ["JETSON_PORT"] = str(addr[1])
+            os.environ["JUMPSTARTER_IN_USE"] = "1"
 
             project_root = Path(__file__).parent.parent
             sys.path.insert(0, str(project_root))

--- a/jumpstarter/wrapper.py
+++ b/jumpstarter/wrapper.py
@@ -32,7 +32,10 @@ with env() as client:
 
         with client.serial.pexpect() as p:
             p.logfile = sys.stdout.buffer
-            p.expect_exact("login:", timeout=600)
+            time.sleep(5)
+            if not p.expect_exact("login:", timeout=600):
+                p.sendline("")
+            p.expect_exact("login:", timeout=30)
             print("Successfully showing login prompt via console")
 
             # password auth needs PermitRootLogin=yes to allow root password login.

--- a/tests_resources/device_ops.py
+++ b/tests_resources/device_ops.py
@@ -145,5 +145,6 @@ def set_kernel_arg(ssh, arg):
         return False
 
     logger.info("Adding kernel argument '%s' via grubby", arg)
+    ssh.sudo("dnf install grubby -y")
     ssh.sudo(f"grubby --update-kernel=ALL --args={arg}")
     return True

--- a/tests_resources/device_ops.py
+++ b/tests_resources/device_ops.py
@@ -10,6 +10,7 @@ import re
 import time
 import logging
 import os
+import pytest
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +64,15 @@ def reboot_and_reconnect(ssh, timeout=300, poll_interval=10):
     Raises:
         TimeoutError: If the device does not come back within the timeout.
     """
+    # Jumpstarter SSH tunnel (TcpPortforwardAdapter) breaks on reboot — the
+    # exporter can't reach the device while it's down, killing the tunnel
+    # permanently.  All subsequent tests would fail with AuthenticationException.
+    if os.environ.get("JUMPSTARTER_IN_USE"):
+        pytest.skip(
+            "Reboot not supported through Jumpstarter SSH tunnel — "
+            "the TCP port-forward breaks when the device goes down"
+        )
+
     # Import here to avoid circular imports (conftest imports ssh_client)
     from tests_suites import conftest as _conftest
     SSHConnection = _conftest.SSHConnection

--- a/tests_resources/device_ops.py
+++ b/tests_resources/device_ops.py
@@ -87,15 +87,13 @@ def reboot_and_reconnect(ssh, timeout=300, poll_interval=10):
 
     # Check if this is a Beaker machine (EFI with RHEL + PXE boot entries)
     original_boot_order, rhel_entry = _get_efi_boot_info(ssh)
-    is_beaker = original_boot_order is not None and rhel_entry is not None
 
-    if is_beaker:
-        logger.info(f"Original boot order: {original_boot_order}")
-        # Set RHEL first in boot order so the machine boots RHEL, not PXE
-        other_entries = [e for e in original_boot_order.split(",") if e != rhel_entry]
-        new_order = ",".join([rhel_entry] + other_entries)
-        logger.info("Beaker machine detected — setting RHEL first in boot order: %s", new_order)
-        ssh.sudo(f"efibootmgr -o {new_order}", print_output=False)
+    logger.info(f"Original boot order: {original_boot_order}")
+    # Set RHEL first in boot order so the machine boots RHEL, not PXE
+    other_entries = [e for e in original_boot_order.split(",") if e != rhel_entry]
+    new_order = ",".join([rhel_entry] + other_entries)
+    logger.info("Beaker machine detected — setting RHEL first in boot order: %s", new_order)
+    ssh.sudo(f"efibootmgr -o {new_order}", print_output=False)
 
     logger.info("Rebooting device %s ...", JETSON_HOST)
     ssh.sudo("reboot", fail_on_rc=False)
@@ -119,13 +117,12 @@ def reboot_and_reconnect(ssh, timeout=300, poll_interval=10):
             )
             logger.info("Reconnected to %s after reboot", JETSON_HOST)
 
-            if is_beaker:
-                # Restore original boot order so Beaker can reclaim via PXE
-                logger.info("Restoring original boot order: %s", original_boot_order)
-                new_ssh.sudo(
-                    f"efibootmgr -o {original_boot_order}",
-                    fail_on_rc=False, print_output=False,
-                )
+            # Restore original boot order so Beaker can reclaim via PXE
+            logger.info("Restoring original boot order: %s", original_boot_order)
+            new_ssh.sudo(
+                f"efibootmgr -o {original_boot_order}",
+                fail_on_rc=False, print_output=False,
+            )
 
             return new_ssh
         except Exception:
@@ -139,7 +136,8 @@ def reboot_and_reconnect(ssh, timeout=300, poll_interval=10):
 
 def set_kernel_arg(ssh, arg):
     """
-    Add a kernel boot argument via grubby if not already present.
+    Add a kernel boot argument if not already present.
+    Tries grubby first, then falls back to ostree kargs for bootc systems.
     Returns True if the argument was added (reboot needed), False if already set.
 
     Args:
@@ -154,7 +152,30 @@ def set_kernel_arg(ssh, arg):
         logger.info("Kernel argument '%s' already set", arg)
         return False
 
+    # Try grubby first
     logger.info("Adding kernel argument '%s' via grubby", arg)
     ssh.sudo("dnf install grubby -y")
     ssh.sudo(f"grubby --update-kernel=ALL --args={arg}")
-    return True
+
+    # Verify grubby actually added it to the default boot entry
+    verify = ssh.sudo("grubby --info=DEFAULT", fail_on_rc=False, print_output=False)
+    if verify.exit_status == 0 and arg in verify.stdout:
+        logger.info("Verified '%s' in default boot entry via grubby", arg)
+        return True
+
+    # grubby didn't apply — try ostree kargs on bootc systems
+    from tests_suites import conftest as _conftest
+    if _conftest.BOOTC_AVAILABLE:
+        logger.warning("grubby did not add '%s' to boot entry, trying ostree kargs", arg)
+        ostree_result = ssh.sudo(
+            f"ostree admin kargs edit-in-place --append-if-missing={arg}",
+            fail_on_rc=False,
+        )
+        if ostree_result.exit_status == 0:
+            logger.info("Added '%s' via ostree admin kargs", arg)
+            return True
+
+    raise RuntimeError(
+        f"Failed to add kernel argument '{arg}' via grubby or ostree (in case of bootc system). "
+        f"grubby --info=DEFAULT output: {verify.stdout}"
+    )

--- a/tests_resources/device_ops.py
+++ b/tests_resources/device_ops.py
@@ -87,6 +87,8 @@ def reboot_and_reconnect(ssh, timeout=300, poll_interval=10):
 
     # Check if this is a Beaker machine (EFI with RHEL + PXE boot entries)
     original_boot_order, rhel_entry = _get_efi_boot_info(ssh)
+    if original_boot_order is None or rhel_entry is None:
+        raise ValueError("Failed to get EFI boot info")
 
     logger.info(f"Original boot order: {original_boot_order}")
     # Set RHEL first in boot order so the machine boots RHEL, not PXE

--- a/tests_suites/conftest.py
+++ b/tests_suites/conftest.py
@@ -2,6 +2,10 @@
 Shared pytest configuration and fixtures for all tests.
 This file imports SSHConnection from infra_tests/ssh_client.py and
 collects hardware info from infra_tests/hardware_info.py for use in all tests.
+
+Test tiers:
+  - Basic tests (default): run with `pytest tests_suites/`
+  - Extra tests: marked with @pytest.mark.extra, run with `pytest tests_suites/ --run-extra`
 """
 import pytest
 import os
@@ -264,3 +268,27 @@ def ssh():
         print(f"\n{error_msg}\n")
         logger.error(error_msg)
         raise
+
+
+# ---------------------------------------------------------------------------
+# Extra-tests support: @pytest.mark.extra tests are excluded by default.
+# Run them with: pytest tests_suites/ --run-extra
+# Or run ONLY extras: pytest tests_suites/ -m extra --run-extra
+# ---------------------------------------------------------------------------
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-extra",
+        action="store_true",
+        default=False,
+        help="Run tests marked with @pytest.mark.extra (skipped by default)",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-extra"):
+        return  # --run-extra given: run everything
+    skip_extra = pytest.mark.skip(reason="Extra test — use --run-extra to run")
+    for item in items:
+        if "extra" in item.keywords:
+            item.add_marker(skip_extra)

--- a/tests_suites/display/conftest.py
+++ b/tests_suites/display/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+from tests_resources.device_ops import reboot_and_reconnect, set_kernel_arg
+
+
+@pytest.fixture(scope="class")
+def ensure_pd_ignore_unused(ssh):
+    """Ensure pd_ignore_unused is in the kernel cmdline before display tests.
+
+    - Already present -> proceed normally
+    - Missing + Beaker -> add via grubby, reboot, return new ssh
+    - Missing + Jumpstarter -> skip (reboot would kill the SSH tunnel)
+    """
+    needs_reboot = set_kernel_arg(ssh, "pd_ignore_unused")
+    if not needs_reboot:
+        yield ssh
+        return
+
+    # Needs reboot to apply. On Jumpstarter this will pytest.skip().
+    new_ssh = reboot_and_reconnect(ssh)
+    # Verify the arg took effect
+    check = new_ssh.run("grep -i pd_ignore_unused /proc/cmdline", fail_on_rc=False)
+    assert check.exit_status == 0, "pd_ignore_unused not in cmdline after reboot"
+    yield new_ssh

--- a/tests_suites/display/test_basic_display.py
+++ b/tests_suites/display/test_basic_display.py
@@ -52,11 +52,12 @@ class TestDisplay:
         result = ssh.run("ls -la /dev/dri/* || ls -la /dev/fb*", fail_on_rc=False)
         assert result.exit_status == 0, f"Failed to check display devices: {result.stderr}"
 
-    def test_display_by_drm(self, ssh, ensure_pd_ignore_unused):
+    def test_display_by_drm(self, ensure_pd_ignore_unused):
         """Test display sysfs entries and DRM connector status.
         Verifies nvidia_drm loading behavior based on systemd target, then checks
         /sys/class/drm/card*-*/status for display connection (see Known Issue #1)."""
-
+        ssh = ensure_pd_ignore_unused
+        
         # Step 1: Check systemd target
         target_result = ssh.run("systemctl get-default", fail_on_rc=False)
         assert target_result.exit_status == 0, f"Failed to get systemd target: {target_result.stderr}"

--- a/tests_suites/display/test_basic_display.py
+++ b/tests_suites/display/test_basic_display.py
@@ -40,7 +40,6 @@ Known Issues
 """
 import pytest
 import warnings
-from tests_resources.device_ops import reboot_and_reconnect, set_kernel_arg
 
 
 class TestDisplay:
@@ -53,7 +52,7 @@ class TestDisplay:
         result = ssh.run("ls -la /dev/dri/* || ls -la /dev/fb*", fail_on_rc=False)
         assert result.exit_status == 0, f"Failed to check display devices: {result.stderr}"
 
-    def test_display_by_drm(self, ssh):
+    def test_display_by_drm(self, ssh, ensure_pd_ignore_unused):
         """Test display sysfs entries and DRM connector status.
         Verifies nvidia_drm loading behavior based on systemd target, then checks
         /sys/class/drm/card*-*/status for display connection (see Known Issue #1)."""
@@ -78,18 +77,10 @@ class TestDisplay:
 
         if not drm_loaded:
             # multi-user.target: nvidia_drm is not auto-loaded, load on demand
-            # for testing DRM on multi-user.target
             load_result = ssh.sudo("modprobe nvidia_drm", fail_on_rc=False)
             assert load_result.exit_status == 0, (
                 f"Failed to load nvidia_drm on demand: {load_result.stderr}"
             )
-
-        # Add pd_ignore_unused to the kernel cmdline and reboot if needed
-        needs_reboot = set_kernel_arg(ssh, "pd_ignore_unused")
-        if needs_reboot:
-            ssh = reboot_and_reconnect(ssh)
-            is_added = set_kernel_arg(ssh, "pd_ignore_unused")
-            assert is_added, "Failed to add pd_ignore_unused to the kernel cmdline"
 
         # Step 4: Test DRM connector status
         result = ssh.run("ls -1 /sys/class/drm/", fail_on_rc=False)
@@ -98,7 +89,6 @@ class TestDisplay:
         assert result.exit_status == 0, f"Failed to check display status: {result.stderr}"
         if "disconnected" in result.stdout.lower():
             warnings.warn(UserWarning("Display is not connected"))
-            # TODO: Try to connect the display for more display testing like xrandr, resolution, etc.
 
     def test_x11_display(self, ssh):
         """Test X11 display is installed on the system.- Warn if not installed."""

--- a/tests_suites/pytest.ini
+++ b/tests_suites/pytest.ini
@@ -6,6 +6,7 @@ addopts =
     #--log-cli-level=INFO
 markers =
     critical: Critical tests that must pass
+    extra: Extra tests (skipped by default, run with --run-extra or -m extra)
     xfail: Tests that are expected to fail
 filterwarnings =
     always::UserWarning


### PR DESCRIPTION
Fixed for Jumpstarter Wrapper and README steps order,
Fixed reboot in case of jumpstarter SSH tunnel,
Fixed reboot in case failing to fetch EFI info,
Add checking in the beginning of the display DRM test for kernel flag that need,
Add extra flag for more tests in the future (in addition to basic ones).
