### PR TITLE
Add JetPack version checking infrastructure and sanity tests

### DIFF
--- a/tests_resources/hardware_info.py
+++ b/tests_resources/hardware_info.py
@@ -1,12 +1,13 @@
 """
 Hardware and system information collection from a Jetson device via SSH.
 
-Provides individual getter functions (e.g. get_rhel_version, get_jetpack_version)
-that any test can call directly, plus a collect() convenience function that gathers
-everything at once (used by tests_suites/conftest.py to set global variables).
+Provides individual getter functions (e.g. get_rhel_version, get_l4t_version,
+get_jetpack_userspace_version) that any test can call directly, plus a collect()
+convenience function that gathers everything at once (used by tests_suites/conftest.py
+to set global variables).
 
 Usage:
-    from tests_resources.hardware_info import get_rhel_version, get_kernel_version
+    from tests_resources.hardware_info import get_rhel_version, get_l4t_version
     rhel = get_rhel_version(ssh)
 
     # Or collect everything at once:
@@ -69,17 +70,19 @@ def _parse_decimal(s: str) -> Optional[Union[float, str]]:
     return None
 
 
-def get_rhel_version(ssh) -> Optional[float]:
-    """Return RHEL version as float (e.g. 9.7), or None if not found."""
+def get_rhel_version(ssh) -> Optional[str]:
+    """Return RHEL version as string (e.g. '9.7', '9.10'), or None if not found.
+    Always returns a string to avoid float precision issues (e.g. float('9.10') == 9.1)."""
     rhel = _run(ssh, "cat /etc/redhat-release")
-    rhel_number = _parse_decimal(rhel)
-    return rhel_number if rhel_number else None
+    if not rhel:
+        return None
+    match = re.search(r"(\d+\.\d+)", rhel)
+    return match.group(1) if match else None
 
 
-def get_jetpack_version(ssh) -> Optional[Union[float, str]]:
-    """Return JetPack version from /etc/nv_tegra_release.
-    Returns str for X.Y.Z (e.g. '36.4.4'), float for X.Y, or None.
-    Note: this file comes from userspace RPMs (e.g. nvidia-jetpack-core), not kmod."""
+def get_l4t_version(ssh) -> Optional[Union[float, str]]:
+    """Return L4T version from /etc/nv_tegra_release (e.g. '36.5.0').
+    Returns str for X.Y.Z, float for X.Y, or None."""
     jetpack_raw = _run(ssh, "head -n 1 /etc/nv_tegra_release")
     if not jetpack_raw:
         return None
@@ -106,6 +109,66 @@ def get_jetpack_version(ssh) -> Optional[Union[float, str]]:
         except ValueError:
             pass
     return _parse_decimal(jetpack_raw)
+
+
+def get_jetpack_userspace_version(ssh) -> Optional[str]:
+    """Return JetPack userspace RPM version (e.g. '6.2.2') from nvidia-jetpack-*-core RPM."""
+    rpm_output = _run(ssh, "rpm -qa | grep 'nvidia-jetpack.*core'")
+    if not rpm_output:
+        return None
+    match = re.search(r"core-(\d+\.\d+\.\d+)", rpm_output)
+    return match.group(1) if match else None
+
+
+# Backward-compat alias: get_jetpack_version now returns userspace RPM version
+get_jetpack_version = get_jetpack_userspace_version
+
+
+def get_jetpack_kmod_version(ssh) -> Optional[str]:
+    """Return JetPack kmod RPM version (e.g. '6.2.2') from nvidia-jetpack-*-kmod RPM."""
+    rpm_output = _run(ssh, "rpm -qa | grep 'nvidia-jetpack.*kmod'")
+    if not rpm_output:
+        return None
+    match = re.search(r"kmod-(\d+\.\d+\.\d+)", rpm_output)
+    return match.group(1) if match else None
+
+
+def get_all_jetpack_rpm_versions(ssh) -> dict[str, str]:
+    """Return dict of {component: version} for all nvidia-jetpack RPMs."""
+    output = _run(ssh, "rpm -qa | grep nvidia-jetpack | sort")
+    if not output:
+        return {}
+    versions = {}
+    for line in output.strip().splitlines():
+        match = re.search(r"nvidia-jetpack-for-rhel-[\d.]+-(.+?)-(\d+\.\d+\.\d+)", line)
+        if match:
+            versions[match.group(1)] = match.group(2)
+    return versions
+
+
+def compare_versions(actual: Optional[Union[float, str]], target: Optional[str]) -> bool:
+    """Exact version comparison. Converts both to strings.
+    For kernel versions (target contains '-'): uses prefix match.
+    Returns True if they match."""
+    if actual is None or target is None:
+        return False
+    actual_str, target_str = str(actual), str(target)
+    if "-" in target_str:
+        return actual_str.startswith(target_str)
+    return actual_str == target_str
+
+
+def compare_versions_gte(actual: Optional[str], target: Optional[str]) -> bool:
+    """Return True if actual version >= target version.
+    Handles X.Y and X.Y.Z formats."""
+    if actual is None or target is None:
+        return False
+    actual_parts = [int(x) for x in str(actual).split(".")]
+    target_parts = [int(x) for x in str(target).split(".")]
+    max_len = max(len(actual_parts), len(target_parts))
+    actual_parts.extend([0] * (max_len - len(actual_parts)))
+    target_parts.extend([0] * (max_len - len(target_parts)))
+    return actual_parts >= target_parts
 
 
 def get_firmware_info(ssh) -> dict[str, Any]:
@@ -198,8 +261,11 @@ def collect(ssh) -> dict[str, Any]:
 
     Returns:
         Dict with keys (all None if value not found):
-        - rhel_version: float | None
-        - jetpack_version: float | str | None (str if X.Y.Z, float if X.Y)
+        - rhel_version: str | None (e.g. '9.7', '9.10')
+        - l4t_version: float | str | None (L4T from /etc/nv_tegra_release)
+        - jetpack_version: str | None (userspace RPM version, e.g. '6.2.2')
+        - jetpack_userspace_version: str | None (same as jetpack_version)
+        - jetpack_kmod_version: str | None (kmod RPM version)
         - firmware_version: float | str | None (str if X.Y.Z, float if X.Y)
         - firmware_type: str | None (e.g. "UEFI", "BIOS")
         - hardware_model_name: str | None
@@ -212,10 +278,16 @@ def collect(ssh) -> dict[str, Any]:
     """
     firmware = get_firmware_info(ssh)
     bootc = get_bootc_info(ssh)
+    l4t = get_l4t_version(ssh)
+    userspace = get_jetpack_userspace_version(ssh)
+    kmod = get_jetpack_kmod_version(ssh)
 
     return {
         "rhel_version": get_rhel_version(ssh),
-        "jetpack_version": get_jetpack_version(ssh),
+        "l4t_version": l4t,
+        "jetpack_version": userspace,
+        "jetpack_userspace_version": userspace,
+        "jetpack_kmod_version": kmod,
         "firmware_version": firmware["firmware_version"],
         "firmware_type": firmware["firmware_type"],
         "hardware_model_name": get_hardware_model_name(ssh),

--- a/tests_suites/README.md
+++ b/tests_suites/README.md
@@ -95,8 +95,10 @@ When running pytest, the session collects hardware and system info from the Jets
 
 | Variable | Type | Description |
 |----------|------|-------------|
-| `RHEL_VERSION` | str or None | RHEL version string (e.g. from `/etc/redhat-release`). |
-| `JETPACK_VERSION` | float, str, or None | Jetpack version: str if X.Y.Z (2 dots), float if X.Y (1 dot). |
+| `RHEL_VERSION` | str or None | RHEL version as string (e.g. `'9.7'`, `'9.10'` from `/etc/redhat-release`). |
+| `L4T_VERSION` | float, str, or None | L4T version from `/etc/nv_tegra_release`: str if X.Y.Z (e.g. `'36.5.0'`), float if X.Y. |
+| `JETPACK_VERSION` | str or None | JetPack userspace RPM version (e.g. `'6.2.2'` from `nvidia-jetpack-*-core` RPM). |
+| `JETPACK_KMOD_VERSION` | str or None | JetPack kmod RPM version (e.g. `'6.2.2'` from `nvidia-jetpack-*-kmod` RPM). |
 | `FIRMWARE_VERSION` | float, str, or None | Firmware version: str if X.Y.Z (2 dots), float if X.Y (1 dot). |
 | `FIRMWARE_TYPE` | str or None | Firmware type (e.g. `UEFI`, `BIOS`). |
 | `HARDWARE_MODEL_NAME` | str or None | Hardware model name. |

--- a/tests_suites/conftest.py
+++ b/tests_suites/conftest.py
@@ -16,7 +16,10 @@ import logging
 from typing import Optional, Union, Dict, Any
 import yaml
 from infra_tests.ssh_client import SSHConnection
-from tests_resources.hardware_info import collect as collect_hardware_info
+from tests_resources.hardware_info import (
+    collect as collect_hardware_info,
+    compare_versions,
+)
 
 # Add project root to path
 project_root = Path(__file__).parent.parent
@@ -55,8 +58,10 @@ if missing_vars:
 # Hardware info variables (set by hardware_info_session fixture; use in tests)
 # All are None by default if value not found.
 # ---------------------------------------------------------------------------
-RHEL_VERSION: Optional[float] = None
-JETPACK_VERSION: Optional[Union[float, str]] = None  # str if X.Y.Z, float if X.Y
+RHEL_VERSION: Optional[str] = None  # str to avoid float('9.10') == 9.1
+L4T_VERSION: Optional[Union[float, str]] = None  # L4T from /etc/nv_tegra_release
+JETPACK_VERSION: Optional[str] = None  # userspace RPM version (e.g. '6.2.2')
+JETPACK_KMOD_VERSION: Optional[str] = None  # kmod RPM version (e.g. '6.2.2')
 FIRMWARE_VERSION: Optional[Union[float, str]] = None  # str if X.Y.Z, float if X.Y
 FIRMWARE_TYPE: Optional[str] = None
 HARDWARE_MODEL_NAME: Optional[str] = None
@@ -95,7 +100,7 @@ def _load_hardware_specs() -> Dict[str, Any]:
     except FileNotFoundError:
         raise ValueError(f"Hardware specs file not found: {path}")
 
-def _install_beaker_repo(ssh, rhel_version: Optional[float]):
+def _install_beaker_repo(ssh, rhel_version: Optional[str]):
     """
     Install Beaker repository on the Jetson.
     RHEL version is required to install the correct Beaker repository.
@@ -129,6 +134,30 @@ def _install_beaker_repo(ssh, rhel_version: Optional[float]):
                   time.sleep(5)
               else:
                   raise
+
+def _get_target_versions(rhel_version: Optional[str]) -> Optional[Dict[str, str]]:
+    """Return target version dict for the given RHEL version, or None."""
+    specs = _load_hardware_specs()
+    targets = specs.get("_target_versions", {})
+    return targets.get(str(rhel_version)) if rhel_version else None
+
+def _verify_target_versions() -> list[str]:
+    """Verify detected versions match targets. Returns list of mismatch messages."""
+    target = _get_target_versions(RHEL_VERSION)
+    if target is None:
+        return []
+    mismatches = []
+    checks = [
+        (FIRMWARE_VERSION, "uefi_firmware_version", "UEFI firmware"),
+        (L4T_VERSION, "l4t_version", "L4T"),
+        (JETPACK_VERSION, "jetpack_userspace_version", "JetPack userspace"),
+        (KERNEL_VERSION, "kernel_version", "Kernel"),
+    ]
+    for actual, key, label in checks:
+        expected = target.get(key)
+        if not compare_versions(actual, expected):
+            mismatches.append(f"{label}: actual={actual}, target={expected}")
+    return mismatches
 
 # ---------------------------------------------------------------------------
 # Public Functions
@@ -175,11 +204,14 @@ def hardware_info_session():
         info = collect_hardware_info(ssh)
 
     # Set module-level variables so all tests can import them
-    global RHEL_VERSION, JETPACK_VERSION, FIRMWARE_VERSION, FIRMWARE_TYPE
+    global RHEL_VERSION, L4T_VERSION, JETPACK_VERSION, JETPACK_KMOD_VERSION
+    global FIRMWARE_VERSION, FIRMWARE_TYPE
     global HARDWARE_MODEL_NAME, KERNEL_VERSION, CPU_ARCH
     global BOOTC_AVAILABLE, BOOTC_VERSION, BOOTC_IMAGE_URL, BOOTC_IMAGE_VERSION
     RHEL_VERSION = info.get("rhel_version")
+    L4T_VERSION = info.get("l4t_version")
     JETPACK_VERSION = info.get("jetpack_version")
+    JETPACK_KMOD_VERSION = info.get("jetpack_kmod_version")
     FIRMWARE_VERSION = info.get("firmware_version")
     FIRMWARE_TYPE = info.get("firmware_type")
     HARDWARE_MODEL_NAME = info.get("hardware_model_name")
@@ -197,21 +229,37 @@ def hardware_info_session():
             "Add the device to tests_suites/jetson_hardware_specs.yaml to run tests."
         )
 
+    # Skip entire session if RHEL version has no target versions defined
+    target = _get_target_versions(RHEL_VERSION)
+    if target is None:
+        pytest.skip(
+            f"Tests not supported yet for RHEL {RHEL_VERSION}. "
+            "Please wait for new changes or add a new target RHEL version entry "
+            "into qe-rhel-jetson/tests_suites/jetson_hardware_specs.yaml under _target_versions."
+        )
+
+    # Skip entire session if detected versions don't match targets
+    mismatches = _verify_target_versions()
+    if mismatches:
+        pytest.skip("Version mismatch — " + "; ".join(mismatches))
+
     # Print SETUP summary for each pytest run (values may be None if not found)
     fw_ver = f" {FIRMWARE_VERSION}" if FIRMWARE_VERSION is not None else ""
     print("\n" + "=" * 80)
     print("SETUP SUMMARY")
     print("=" * 80)
-    print(f"Hardware model name:   {HARDWARE_MODEL_NAME}")
+    print(f"Hardware model name:         {HARDWARE_MODEL_NAME}")
     print("=" * 80)
-    print(f"1. RHEL version:          {RHEL_VERSION}")
-    print(f"2. Kernel version:        {KERNEL_VERSION}")
-    print(f"3. Jetpack Version:       {JETPACK_VERSION}")
-    print(f"4. Firmware type/version: {FIRMWARE_TYPE}{fw_ver}")
-    print("=" * 80 )
-    print(f"5. Bootc available:       {BOOTC_AVAILABLE}")
-    print(f"6. Bootc image version:   {BOOTC_IMAGE_VERSION}")
-    print(f"7. Bootc image URL:       {BOOTC_IMAGE_URL}")
+    print(f"1. RHEL version:             {RHEL_VERSION}")
+    print(f"2. Kernel version:           {KERNEL_VERSION}")
+    print(f"3. L4T version:              {L4T_VERSION}")
+    print(f"4. JetPack version (RPM):    {JETPACK_VERSION}")
+    print(f"5. JetPack kmod (RPM):       {JETPACK_KMOD_VERSION}")
+    print(f"6. Firmware type/version:    {FIRMWARE_TYPE}{fw_ver}")
+    print("=" * 80)
+    print(f"7. Bootc available:          {BOOTC_AVAILABLE}")
+    print(f"8. Bootc image version:      {BOOTC_IMAGE_VERSION}")
+    print(f"9. Bootc image URL:          {BOOTC_IMAGE_URL}")
     print("=" * 80 + "\n")
     yield
 

--- a/tests_suites/display/conftest.py
+++ b/tests_suites/display/conftest.py
@@ -20,7 +20,7 @@ def ensure_pd_ignore_unused(ssh):
     - RHEL 9.7 + multi-user.target + missing + Jumpstarter -> skip (reboot kills tunnel)
     """
     # Only needed on RHEL 9.7; skip when version unknown or not 9.7
-    if RHEL_VERSION is None or float(RHEL_VERSION) != 9.7:
+    if RHEL_VERSION is None or RHEL_VERSION != "9.7":
         yield ssh
         return
 

--- a/tests_suites/jetson_hardware_specs.yaml
+++ b/tests_suites/jetson_hardware_specs.yaml
@@ -6,6 +6,18 @@
 # Reference: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/#:~:text=View%20Jetson%20Orin%20Technical%20Specifications
 
 # -----------------------------------------------------------------------------
+# Target versions per RHEL release (used by sanity tests and session skip logic)
+# -----------------------------------------------------------------------------
+_target_versions:
+  "9.7":
+    rhel_version: "9.7"
+    l4t_version: "36.5.0"
+    jetpack_userspace_version: "6.2.2"
+    jetpack_kmod_version: "6.2.2"
+    uefi_firmware_version: "36.4.4"
+    kernel_version: "5.14.0-611.38.1"
+
+# -----------------------------------------------------------------------------
 # Shared templates (anchors for merge; not used as match keys)
 # -----------------------------------------------------------------------------
 _templates:

--- a/tests_suites/sanity/test_version_check.py
+++ b/tests_suites/sanity/test_version_check.py
@@ -1,0 +1,45 @@
+"""
+Sanity tests for JetPack version consistency.
+
+Individual target version checks (RHEL, L4T, userspace, kernel, firmware, [except kmod])
+are handled by session-level skip logic in conftest.py. These tests verify
+cross-component consistency that the skip logic doesn't cover. (along with checking kmod version)
+"""
+import pytest
+from tests_resources.hardware_info import (
+    get_all_jetpack_rpm_versions,
+    compare_versions_gte,
+)
+from tests_suites.conftest import JETPACK_VERSION, JETPACK_KMOD_VERSION
+
+
+class TestVersionConsistency:
+    """Cross-component version consistency checks."""
+
+    def test_all_userspace_rpms_same_version(self, ssh):
+        """All non-kmod nvidia-jetpack RPMs must have the same version as the core RPM."""
+        rpm_versions = get_all_jetpack_rpm_versions(ssh)
+        assert rpm_versions, "No nvidia-jetpack RPMs found on the device"
+
+        # Separate kmod from userspace components
+        userspace = {k: v for k, v in rpm_versions.items() if "kmod" not in k}
+        assert userspace, "No userspace nvidia-jetpack RPMs found"
+
+        core_version = userspace.get("core")
+        assert core_version is not None, (
+            f"nvidia-jetpack core RPM not found. Found components: {list(userspace.keys())}"
+        )
+
+        mismatched = {k: v for k, v in userspace.items() if v != core_version}
+        assert not mismatched, (
+            f"Userspace RPM version mismatch (expected {core_version}): {mismatched}"
+        )
+
+    def test_kmod_version_gte_userspace(self, ssh):
+        """JetPack kmod RPM version must be >= userspace RPM version."""
+        assert JETPACK_VERSION is not None, "JetPack userspace version not detected"
+        assert JETPACK_KMOD_VERSION is not None, "JetPack kmod version not detected"
+        assert compare_versions_gte(JETPACK_KMOD_VERSION, JETPACK_VERSION), (
+            f"JetPack kmod version ({JETPACK_KMOD_VERSION}) is older than "
+            f"userspace version ({JETPACK_VERSION})"
+        )


### PR DESCRIPTION
1. Add get_l4t_version, get_jetpack_userspace_version, get_jetpack_kmod_version, get_all_jetpack_rpm_versions, compare_versions, compare_versions_gte to hardware_info.py

2. Change RHEL_VERSION from float to str to avoid float('9.10') == 9.1 precision loss

3. Repurpose JETPACK_VERSION to hold userspace RPM version; add L4T_VERSION and JETPACK_KMOD_VERSION globals

4. Add _target_versions to jetson_hardware_specs.yaml with RHEL 9.7 target versions (L4T 36.5.0, JetPack 6.2.2, UEFI 36.4.4)

5. Add session-level skip logic in conftest.py when RHEL version unsupported or detected versions mismatch targets

6. Create tests_suites/sanity/ with cross-component consistency tests (RPM version uniformity, kmod >= userspace)