### PR TITLE
Fix SSH IPv6 timeout, fix jumpstarter's wrapper in case tcp not found in client.ssh, refactor logging, and fix test issues

### DIFF
--- a/infra_tests/ssh_client.py
+++ b/infra_tests/ssh_client.py
@@ -56,11 +56,13 @@ class SSHConnection(Connection):
         )
 
         # Step 1: quick TCP check (fails here if host unreachable or you need ProxyJump)
+        # also, saving the socket to pre_connected_sock so we can use it for the paramiko connection.
+        pre_connected_sock = None
         try:
             logger.info("[SSH debug] Step 1: TCP connect to %s:%s ...", hostname, port)
             sock = socket.create_connection((hostname, port), timeout=timeout)
-            sock.close()
-            logger.info("[SSH debug] Step 1: TCP connect OK")
+            pre_connected_sock = sock
+            logger.info("[SSH debug] Step 1: TCP connect OK, and saved the socket")
         except OSError as e:
             logger.error("[SSH debug] Step 1 FAILED (TCP): %s", e)
             raise
@@ -75,6 +77,7 @@ class SSHConnection(Connection):
         connect_kwargs: dict = {
             "allow_agent": False,
             "look_for_keys": False,
+            "sock": pre_connected_sock, # use the pre-connected socket to avoid the paramiko's own address resolution (which handles IPv6→IPv4 fallback).
         }
         if key_filename:
             connect_kwargs["key_filename"] = key_filename
@@ -93,9 +96,10 @@ class SSHConnection(Connection):
             connect_kwargs=connect_kwargs,
         )
 
+        #This is needed because Beaker reprovisioning gives each Jetson a new host key every time, so it's never in known_hosts.
         self.client.set_missing_host_key_policy(paramiko.WarningPolicy())
 
-        # Step 3: Fabric SSH connect (retry on timeout - lab links can be flaky)
+        # Step 3: Fabric SSH connect (retry on failed handshake, or timeout- lab links can be flaky)
         last_error = None
         for attempt in range(1, 4):  # up to 3 attempts
             try:
@@ -113,6 +117,16 @@ class SSHConnection(Connection):
                 )
                 if attempt < 3:
                     time.sleep(2)
+                    # The previous socket is consumed/closed after a failed
+                    # handshake, so create a fresh one for the next attempt.
+                    try:
+                        new_sock = socket.create_connection((hostname, port), timeout=timeout)
+                        self.connect_kwargs["sock"] = new_sock
+                    except OSError as sock_err:
+                        logger.warning(
+                            "[SSH debug] Step 3: Socket reconnect failed: %s",
+                            sock_err,
+                        )
         if last_error is not None:
             logger.error(
                 "[SSH debug] Step 3: FAILED (Fabric) after 3 attempts: %s",
@@ -142,14 +156,13 @@ class SSHConnection(Connection):
         ]
         # Import here to avoid circular import (conftest imports ssh_client)
         from tests_suites import conftest as _conftest
-        # if bootc is available, add --transient to the dnf commands
+        # if bootc is available, add --transient to mutating dnf commands
         if _conftest.BOOTC_AVAILABLE:
-            # Split the command into parts to check the actual sub-command accurately
             cmd_parts = command.split()
-            if any(sub_cmd in cmd_parts for sub_cmd in MUTATING_DNF_COMMANDS):
-                # Ensure we don't double-add the flag if it's already there
-                if "--transient" not in command:
-                    command += " --transient"
+            if cmd_parts and cmd_parts[0] == "dnf":
+                if any(sub_cmd in cmd_parts for sub_cmd in MUTATING_DNF_COMMANDS):
+                    if "--transient" not in command:
+                        command += " --transient"
         return command
 
     def run(
@@ -173,7 +186,8 @@ class SSHConnection(Connection):
         command = self._mutate_command(command)
 
         if print_output:
-            print("\t\tRunning command:", command)
+            string_logger_formatted = f"\t\t[Fabric] Running command: {command}"
+            logger.info(string_logger_formatted)
 
         result = super().run(command, timeout=timeout, warn=True, hide=True)
         # Create a result-like object similar to Fabric's result
@@ -189,11 +203,12 @@ class SSHConnection(Connection):
         )()
 
         if print_output:
-            print("\t\tstdout:", result.stdout)
+            string_logger_formatted = f"\t\t[Fabric] stdout: \n{result.stdout}"
+            logger.info(string_logger_formatted)
 
         if fail_on_rc and result.exit_status != expect_rc:
             raise RuntimeError(
-                f"Command '{command}' failed with exit status {result.exit_status}. Expected {expect_rc}. Error: {result.stderr}. \n\t\tOutput: {result.stdout}"
+                f"Command '{command}' failed with exit status {result.exit_status}. Expected {expect_rc}. Error: {result.stderr}. \n\t\tOutput: \n{result.stdout}"
             )
 
         return result
@@ -220,7 +235,8 @@ class SSHConnection(Connection):
         command = self._mutate_command(command)
 
         if print_output:
-            print("\t\tRunning command:", command)
+            string_logger_formatted = f"\t\t[Fabric] Running command: {command}"
+            logger.info(string_logger_formatted)
 
         result = super().sudo(command, timeout=timeout, warn=True, hide=True)
         # Create a result-like object similar to Fabric's result
@@ -236,11 +252,12 @@ class SSHConnection(Connection):
         )()
 
         if print_output:
-            print("\t\tstdout:", result.stdout)
+            string_logger_formatted = f"\t\t[Fabric] stdout: \n{result.stdout}"
+            logger.info(string_logger_formatted)
 
         if fail_on_rc and result.exit_status != expect_rc:
             raise RuntimeError(
-                f"Command '{command}' failed with exit status {result.exit_status}. Expected {expect_rc}. Error: {result.stderr}. \n\t\tOutput: {result.stdout}"
+                f"Command '{command}' failed with exit status {result.exit_status}. Expected {expect_rc}. Error: {result.stderr}. \n\t\tOutput: \n{result.stdout}"
             )
 
         return result

--- a/jumpstarter/wrapper.py
+++ b/jumpstarter/wrapper.py
@@ -5,8 +5,9 @@ import sys
 import os
 import subprocess
 from pathlib import Path
+from logging import getLogger
 
-
+logger = getLogger(__name__)
 USERNAME = os.environ.get("JETSON_USERNAME")
 PASSWORD = os.environ.get("JETSON_PASSWORD")
 KEY_PATH = os.environ.get("JETSON_KEY_PATH")
@@ -26,9 +27,9 @@ if key_filename and not os.path.exists(key_filename):
 with env() as client:
     with client.log_stream():
         client.storage.dut()
-        print("[wrapper] Storage connected to DUT")
+        logger.info("[wrapper] Storage connected to DUT")
         client.power.cycle()
-        print("[wrapper] DUT powered on")
+        logger.info("[wrapper] DUT powered on")
 
         with client.serial.pexpect() as p:
             p.logfile = sys.stdout.buffer
@@ -42,7 +43,7 @@ with env() as client:
                     got_login = True
                     break
                 else:
-                    print(f"\n[wrapper] Device stuck at grub> (attempt {attempt + 1}/3), sending 'exit' to force reboot...")
+                    logger.info(f"\n[wrapper] Device stuck at grub> (attempt {attempt + 1}/3), sending 'exit' to force reboot...")
                     p.sendline("exit")
                     time.sleep(10)
 
@@ -52,12 +53,12 @@ with env() as client:
             # Send Enter to get a fresh login: prompt
             p.sendline("")
             p.expect_exact("login:", timeout=30)
-            print("[wrapper] Successfully showing login prompt via console")
+            logger.info("[wrapper] Successfully showing login prompt via console")
 
             # password auth needs PermitRootLogin=yes to allow root password login.
             # (RHEL bootc defaults to prohibit-password which blocks root password login).
             if PASSWORD:
-                print("[wrapper] Configuring SSH root password login via serial console...")
+                logger.info("[wrapper] Configuring SSH root password login via serial console...")
                 # The first "login:" might match a systemd message during boot
                 # Send Enter to get a fresh, reliable login prompt.
                 time.sleep(2)
@@ -77,15 +78,16 @@ with env() as client:
                     " && echo WRAPPER_SSH_CONFIG_OK"
                 )
                 p.expect_exact("WRAPPER_SSH_CONFIG_OK", timeout=30)
-                print("[wrapper] SSH root login enabled and sshd restarted")
+                logger.info("[wrapper] SSH root login enabled and sshd restarted")
 
                 p.sendline("exit")
 
         # Wait for SSH service to be fully ready after sshd restart
-        print("[wrapper] Waiting for SSH service to start...")
+        logger.info("[wrapper] Waiting for SSH service to start...")
         time.sleep(10)
 
-        with TcpPortforwardAdapter(client=client.ssh.tcp) as addr:
+        ssh_client = client.ssh.tcp if hasattr(client.ssh, 'tcp') else client.ssh
+        with TcpPortforwardAdapter(client=ssh_client) as addr:
             os.environ["JETSON_HOST"] = addr[0]
             os.environ["JETSON_PORT"] = str(addr[1])
             os.environ["JUMPSTARTER_IN_USE"] = "1"
@@ -103,7 +105,7 @@ with env() as client:
             ) as ssh:
                 ssh.sudo("/usr/libexec/bootc-generic-growpart")
 
-            print(f"[wrapper] Launching pytest with JETSON_HOST={os.environ['JETSON_HOST']} "
+            logger.info(f"[wrapper] Launching pytest with JETSON_HOST={os.environ['JETSON_HOST']} "
                   f"JETSON_PORT={os.environ['JETSON_PORT']} "
                   f"JETSON_USERNAME={os.environ.get('JETSON_USERNAME')} "
                   f"JETSON_KEY_PATH={os.environ.get('JETSON_KEY_PATH', '(not set)')}")

--- a/tests_resources/device_ops.py
+++ b/tests_resources/device_ops.py
@@ -121,10 +121,7 @@ def reboot_and_reconnect(ssh, timeout=300, poll_interval=10):
 
             # Restore original boot order so Beaker can reclaim via PXE
             logger.info("Restoring original boot order: %s", original_boot_order)
-            new_ssh.sudo(
-                f"efibootmgr -o {original_boot_order}",
-                fail_on_rc=False, print_output=False,
-            )
+            new_ssh.sudo(f"efibootmgr -o {original_boot_order}", print_output=False)
 
             return new_ssh
         except Exception:

--- a/tests_suites/README.md
+++ b/tests_suites/README.md
@@ -80,6 +80,11 @@ Run with verbose output:
 pytest -v tests_suites/
 ```
 
+Run with log level:
+```bash
+pytest -v tests_suites/ --log-cli-level=INFO
+```
+
 ## How to Warn
 
 for more information look at tests_suites/WARNING_BEHAVIOR.md

--- a/tests_suites/conftest.py
+++ b/tests_suites/conftest.py
@@ -322,8 +322,7 @@ def ssh():
             f"  - Firewall allows SSH connections\n"
             f"  - Network connectivity is available"
         )
-        print(f"\n{error_msg}\n")
-        logger.error(error_msg)
+        logger.error(f"\n[conftest] {error_msg}\n")
         raise
 
 

--- a/tests_suites/cuda/test_basic_cuda.py
+++ b/tests_suites/cuda/test_basic_cuda.py
@@ -23,9 +23,8 @@ class TestCUDA:
         tmp = ssh.run("mktemp -d").stdout.strip()
         ssh.put(FILE / "Dockerfile", f"{tmp}/Dockerfile")
         result = ssh.sudo(
-            "podman build --build-arg CACHEBUST={} --device nvidia.com/gpu=all {}".format(
-                datetime.now().timestamp(), tmp
-            )
+            "podman build --build-arg CACHEBUST={} --device nvidia.com/gpu=all {}".format(datetime.now().timestamp(), tmp)
+            , fail_on_rc=False
         )
         assert result.exit_status == 0, f"CUDA test failed: {result.stderr}"
 
@@ -33,7 +32,7 @@ class TestCUDA:
         """Test CUDA with NVIDIA deviceQuery sample (GPU properties)."""
         result = ssh.sudo(
             "podman run --rm --device nvidia.com/gpu=all {} deviceQuery".format(CUDA_SAMPLES_IMAGE),
-            timeout=120
+            timeout=120, fail_on_rc=False
         )
         assert result.exit_status == 0, f"CUDA deviceQuery failed: {result.stderr}"
         assert "CUDA" in result.stdout, "CUDA deviceQuery produced no CUDA output"
@@ -42,6 +41,6 @@ class TestCUDA:
         """Test CUDA with NVIDIA bandwidthTest sample (memory bandwidth)."""
         result = ssh.sudo(
             "podman run --rm --device nvidia.com/gpu=all {} bandwidthTest".format(CUDA_SAMPLES_IMAGE),
-            timeout=120
+            timeout=120, fail_on_rc=False
         )
         assert result.exit_status == 0, f"CUDA bandwidthTest failed: {result.stderr}"

--- a/tests_suites/display/conftest.py
+++ b/tests_suites/display/conftest.py
@@ -1,8 +1,11 @@
 import pytest
 from tests_resources.device_ops import reboot_and_reconnect, set_kernel_arg, get_systemd_target
-from tests_suites.conftest import RHEL_VERSION
+from tests_suites import conftest as _conftest
 import os
 import warnings
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="class")
@@ -20,17 +23,17 @@ def ensure_pd_ignore_unused(ssh):
     - RHEL 9.7 + multi-user.target + missing + Jumpstarter -> skip (reboot kills tunnel)
     """
     # Only needed on RHEL 9.7; skip when version unknown or not 9.7
-    if RHEL_VERSION is None or RHEL_VERSION != "9.7":
+    if _conftest.RHEL_VERSION is None or _conftest.RHEL_VERSION != "9.7":
         yield ssh
         return
 
     # graphical.target loads nvidia_drm safely - no need to add pd_ignore_unused
     if get_systemd_target(ssh) == "graphical.target":
         yield ssh
-        print("graphical.target - skipping pd_ignore_unused")
+        logger.info("graphical.target - skipping pd_ignore_unused")
         return
 
-    print("setting pd_ignore_unused is needed (RHEL 9.7 + non graphical.target)")
+    logger.info("setting pd_ignore_unused is needed (RHEL 9.7 + non graphical.target)")
     needs_reboot = set_kernel_arg(ssh, "pd_ignore_unused")
     if not needs_reboot:
         yield ssh
@@ -38,7 +41,7 @@ def ensure_pd_ignore_unused(ssh):
 
     # Needs reboot to apply. On Jumpstarter this will pytest.skip().
     if os.environ.get("JUMPSTARTER_IN_USE"):
-        print("Reboot was needed to set pd_ignore_unused, but not supported through Jumpstarter SSH tunnel")
+        logger.info("Reboot was needed to set pd_ignore_unused, but not supported through Jumpstarter SSH tunnel")
         warnings.warn(
             "Reboot was needed to set pd_ignore_unused (see jumpstarter/README.md), "
             "but not supported through Jumpstarter SSH tunnel — the TCP port-forward breaks when the device goes down",

--- a/tests_suites/display/test_basic_display.py
+++ b/tests_suites/display/test_basic_display.py
@@ -44,6 +44,8 @@ Known Issues
 import pytest
 import warnings
 from tests_resources.device_ops import get_systemd_target
+from logging import getLogger
+logger = getLogger(__name__)
 
 
 class TestDisplay:
@@ -68,7 +70,7 @@ class TestDisplay:
         # Step 2: Check if nvidia_drm is loaded
         drm_mod = ssh.run("lsmod | grep nvidia_drm", fail_on_rc=False)
         drm_loaded = drm_mod.exit_status == 0
-        print(f"drm_loaded: {drm_loaded}")
+        logger.info(f"[test_display_by_drm] drm_loaded: {drm_loaded}")
 
         # Step 3: Handle based on target + module state
         if systemd_target == "graphical.target" and not drm_loaded:

--- a/tests_suites/ethernet/test_basic_ethernet.py
+++ b/tests_suites/ethernet/test_basic_ethernet.py
@@ -13,6 +13,6 @@ class TestEthernet:
 
     def test_ethernet_driver_loaded(self, ssh):
         """Test Ethernet driver is loaded."""
-        result = ssh.run("lsmod | grep -iE 'eqos|stmmac|dwmac|r8169|e1000|igb|realtek|xgbe|nfp'")
+        result = ssh.run("lsmod | grep -iE 'eqos|stmmac|dwmac|r8169|e1000|igb|realtek|xgbe|nfp'", fail_on_rc=False)
         # Ethernet drivers may have various names, so we just check if command succeeds
         assert result.exit_status == 0, f"Failed to check Ethernet drivers: {result.stderr}"

--- a/tests_suites/kmod/test_basic_kmod.py
+++ b/tests_suites/kmod/test_basic_kmod.py
@@ -16,7 +16,7 @@ class TestKmod:
 
     def test_tegra_devices(self, ssh):
         """Test Tegra device nodes are present (/dev/tegra*)."""
-        result = ssh.sudo("ls -la /dev/tegra*")
+        result = ssh.sudo("ls -la /dev/tegra*", fail_on_rc=False)
         assert result.exit_status == 0, f"Failed to list Tegra devices: {result.stderr}"
 
     def test_nvidia_kernel_modules(self, ssh):

--- a/tests_suites/pcis/test_basic_pcis.py
+++ b/tests_suites/pcis/test_basic_pcis.py
@@ -5,7 +5,8 @@ Based on test_basic.py and test_basic_locally.py from edge-ai-image-pipelines.
 import re
 import pytest
 from tests_suites import conftest as _conftest
-
+from logging import getLogger
+logger = getLogger(__name__)
 
 def parse_lnkcap_lines(lspci_output: str) -> list[dict]:
     """
@@ -43,7 +44,7 @@ class TestPCIs:
 
     def test_pcie(self, ssh):
         """Test PCI devices are present."""
-        result = ssh.sudo("ls -1 /sys/bus/pci/devices/")
+        result = ssh.sudo("ls -1 /sys/bus/pci/devices/", fail_on_rc=False)
         assert result.exit_status == 0, f"Failed to list PCI devices: {result.stderr}"
         assert len(result.stdout.splitlines()) > 0, "No PCI devices found"
 
@@ -66,7 +67,7 @@ class TestPCIs:
         
         ssh.sudo("dnf install pciutils -y")
         
-        result = ssh.sudo("lspci -vv | grep -P 'LnkCap:'")
+        result = ssh.sudo("lspci -vv | grep -P 'LnkCap:'", fail_on_rc=False)
         assert result.exit_status == 0, "No PCIe LnkCap information found. Is lspci working?"
         
         detected_links = parse_lnkcap_lines(result.stdout)
@@ -106,7 +107,7 @@ class TestPCIs:
         )
         
         # Log what was found for informational purposes
-        print(f"\nPCIe capability check passed:")
-        print(f"  Expected generation: Gen{max_expected_gen} ({max_expected_speed})")
-        print(f"  Detected {len(detected_links)} link(s):")
-        print(detected_summary)
+        logger.info(f"\nPCIe capability check passed:")
+        logger.info(f"  Expected generation: Gen{max_expected_gen} ({max_expected_speed})")
+        logger.info(f"  Detected {len(detected_links)} link(s):")
+        logger.info(detected_summary)

--- a/tests_suites/pva/test_basic_pva.py
+++ b/tests_suites/pva/test_basic_pva.py
@@ -35,6 +35,6 @@ class TestPVA:
             result = ssh.sudo(
                 "podman build --build-arg CACHEBUST={} --device nvidia.com/gpu=all {}".format(
                     datetime.now().timestamp(), tmp
-                )
+                ), fail_on_rc=False
             )
             assert result.exit_status == 0, f"PVA test failed: {result.stderr}"

--- a/tests_suites/sanity/test_signature_check.py
+++ b/tests_suites/sanity/test_signature_check.py
@@ -5,7 +5,8 @@ Verifies that NVIDIA kernel modules are signed for Secure Boot compatibility.
 This ensures the modules will load correctly when Secure Boot is enabled.
 """
 import pytest
-
+from logging import getLogger
+logger = getLogger(__name__)
 
 NVIDIA_KERNEL_MODULES = [
     "nvgpu",
@@ -49,7 +50,7 @@ class TestKernelModuleSignatures:
                 unsigned_modules.append(module)
 
         if missing_modules:
-            print(f"Missing modules (not loaded): {missing_modules}")
+            logger.info(f"[test_nvidia_modules_are_signed] Missing modules (not loaded): {missing_modules}")
 
         assert not unsigned_modules, (
             f"The following NVIDIA kernel modules are NOT signed for Secure Boot:\n"
@@ -95,6 +96,6 @@ class TestKernelModuleSignatures:
             f"Signature info:\n{result.stdout}"
         )
 
-        print(f"nvgpu signature details:\n{result.stdout}")
+        logger.info(f"[test_nvidia_module_signature_details] nvgpu signature details:\n{result.stdout}")
 
     #TODO add secure boot check

--- a/tests_suites/sanity/test_version_check.py
+++ b/tests_suites/sanity/test_version_check.py
@@ -10,7 +10,9 @@ from tests_resources.hardware_info import (
     get_all_jetpack_rpm_versions,
     compare_versions_gte,
 )
-from tests_suites.conftest import JETPACK_VERSION, JETPACK_KMOD_VERSION
+from tests_suites import conftest
+from logging import getLogger
+logger = getLogger(__name__)
 
 
 class TestVersionConsistency:
@@ -19,27 +21,33 @@ class TestVersionConsistency:
     def test_all_userspace_rpms_same_version(self, ssh):
         """All non-kmod nvidia-jetpack RPMs must have the same version as the core RPM."""
         rpm_versions = get_all_jetpack_rpm_versions(ssh)
+        logger.info(f"All nvidia-jetpack RPMs: {rpm_versions}")
         assert rpm_versions, "No nvidia-jetpack RPMs found on the device"
 
         # Separate kmod from userspace components
         userspace = {k: v for k, v in rpm_versions.items() if "kmod" not in k}
+        logger.info(f"Userspace nvidia-jetpack RPMs: {userspace}")
         assert userspace, "No userspace nvidia-jetpack RPMs found"
 
         core_version = userspace.get("core")
+        logger.info(f"Jetpack Core version: {core_version}")
         assert core_version is not None, (
             f"nvidia-jetpack core RPM not found. Found components: {list(userspace.keys())}"
         )
 
         mismatched = {k: v for k, v in userspace.items() if v != core_version}
+        logger.info(f"Mismatched userspace RPMs: {mismatched}")
         assert not mismatched, (
             f"Userspace RPM version mismatch (expected {core_version}): {mismatched}"
         )
 
     def test_kmod_version_gte_userspace(self, ssh):
         """JetPack kmod RPM version must be >= userspace RPM version."""
-        assert JETPACK_VERSION is not None, "JetPack userspace version not detected"
-        assert JETPACK_KMOD_VERSION is not None, "JetPack kmod version not detected"
-        assert compare_versions_gte(JETPACK_KMOD_VERSION, JETPACK_VERSION), (
-            f"JetPack kmod version ({JETPACK_KMOD_VERSION}) is older than "
-            f"userspace version ({JETPACK_VERSION})"
+        logger.info(f"JetPack userspace version: {conftest.JETPACK_VERSION}")
+        logger.info(f"JetPack kmod version: {conftest.JETPACK_KMOD_VERSION}")
+        assert conftest.JETPACK_VERSION is not None, "JetPack userspace version not detected"
+        assert conftest.JETPACK_KMOD_VERSION is not None, "JetPack kmod version not detected"
+        assert compare_versions_gte(conftest.JETPACK_KMOD_VERSION, conftest.JETPACK_VERSION), (
+            f"JetPack kmod version ({conftest.JETPACK_KMOD_VERSION}) is older than "
+            f"userspace version ({conftest.JETPACK_VERSION})"
         )

--- a/tests_suites/tools/test_basic_tools.py
+++ b/tests_suites/tools/test_basic_tools.py
@@ -5,6 +5,8 @@ Covers nvidia-jetpack-tools: nvpmodel (power model) and nvfancontrol.
 import re
 import pytest
 from tests_suites import conftest as _conftest
+from logging import getLogger   
+logger = getLogger(__name__)
 
 
 def _power_modes_spec(spec):
@@ -23,7 +25,7 @@ def _parse_wattage_from_stdout(stdout):
     """Extract wattage values (e.g. 15, 30, 60) from nvpmodel output. Returns list of ints."""
     # Match numbers followed by 'W' (e.g. "15W", "60 W", "MODE_30W", "NV Power Mode: MODE_30W")
     matches = re.findall(r"(\d+)\s*W\b", stdout, re.IGNORECASE)
-    print(f"matches: {matches}")
+    logger.info(f"[test_basic_tools] _parse_wattage_from_stdout] matches: {matches}")
     return [int(m) for m in matches] if matches else []
 
 
@@ -37,7 +39,7 @@ class TestTools:
         assert kind in ("list", "range"), (
             f"power_modes in jetson_hardware_specs must be a list (specific) or {{min, max}} (range); got {power_modes_val!r}"
         )
-        result = ssh.run("nvpmodel -q")
+        result = ssh.run("nvpmodel -q", fail_on_rc=False)
         assert result.exit_status == 0, f"nvpmodel -q failed: {result.stderr}"
         assert result.stdout.strip(), "nvpmodel produced no output"
         # Check if the power model is a number in the second line of the output
@@ -64,8 +66,8 @@ class TestTools:
 
     def test_nvfancontrol_available(self, ssh):
         """Test nvfancontrol is available (nvidia-jetpack-tools)."""
-        which_result = ssh.run("which nvfancontrol")
+        which_result = ssh.run("which nvfancontrol", fail_on_rc=False)
         if not which_result.stdout.strip():
             pytest.skip("nvfancontrol not in PATH")
-        result = ssh.sudo("nvfancontrol -q")
+        result = ssh.sudo("nvfancontrol -q", fail_on_rc=False)
         assert result.exit_status == 0, f"nvfancontrol failed: {result.stderr}"

--- a/tests_suites/usbs/test_basic_usbs.py
+++ b/tests_suites/usbs/test_basic_usbs.py
@@ -16,7 +16,7 @@ class TestUSBs:
 
     def test_usb(self, ssh):
         """Test USB devices are present."""
-        result = ssh.sudo("ls -1 /sys/bus/usb/devices/")
+        result = ssh.sudo("ls -1 /sys/bus/usb/devices/", fail_on_rc=False)
         assert result.exit_status == 0, f"Failed to list USB devices: {result.stderr}"
         assert len(result.stdout.splitlines()) > 0, "No USB devices found"
 

--- a/tests_suites/video_enc_dec/test_basic_video_enc_dec.py
+++ b/tests_suites/video_enc_dec/test_basic_video_enc_dec.py
@@ -26,5 +26,6 @@ class TestVideoEncDec:
         else:
           result = ssh.sudo(
               "gst-launch-1.0 videotestsrc num-buffers=300 ! nvvidconv ! nvv4l2h264enc ! nvv4l2decoder ! fakesink"
+              , fail_on_rc=False
           )
         assert result.exit_status == 0, f"Video acceleration test failed: {result.stderr}"


### PR DESCRIPTION
...

1. Fix SSH IPv6 timeout by passing pre-connected socket to paramiko — skips paramiko's broken IPv6-first resolution that hangs 60s on networks that can't route IPv6 (ssh_client.py)

2. Add fresh socket reconnection on Step 3 retry failures — previous socket is consumed/closed after a failed SSH handshake (ssh_client.py)

3. Scope _mutate_command --transient flag to dnf commands only — previously any command containing "install"/"update" would match (ssh_client.py)

4. Fix import-by-value bug for conftest globals in test_version_check.py and display/conftest.py — importing a variable copies its initial None value instead of reading the updated value at test time

5. Add fail_on_rc=False where exit_status is checked (pva, tools, conftest)

6. Replace print() with logger.info() in wrapper.py, display/conftest.py, and ssh_client.py — logger integrates with Python logging framework for better log capture

7. Add safe access for client.ssh.tcp in wrapper.py with hasattr fallback