### PR TITLE
Add collect logs fixture in teardown for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ beaker/ansible/vars/secrets.yml
 .claude/
 CLAUDE.md
 
+# Device logs (collected at test teardown)
+device_logs/
+
 # Jumpstarter resources
 config.toml
 output/

--- a/tests_resources/device_logs_collector.py
+++ b/tests_resources/device_logs_collector.py
@@ -1,0 +1,153 @@
+"""
+Device logs collector — collects diagnostic logs from a Jetson device via SSH,
+packages them into a tar.gz archive, and saves locally.
+
+Usage:
+    from tests_resources.device_logs_collector import save_device_logs
+    archive_path = save_device_logs(ssh, bootc_image_url, output_dir)
+"""
+import io
+import os
+import re
+import tarfile
+import logging
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Optional
+
+from tests_resources.hardware_info import (
+    collect as collect_hardware_info,
+    get_log_secure_boot_state,
+    get_log_modinfo_host1x,
+    get_log_modinfo_tegra_drm,
+    get_log_modinfo_nvgpu,
+    get_log_module_files_updates,
+    get_log_nvidia_modules_dep,
+    get_log_modprobe_nvidia,
+    get_log_journalctl_current_boot,
+    get_log_journalctl_all,
+    get_log_dmesg_all,
+    get_log_dmesg_nvidia_errors,
+    get_log_nvidia_rpms,
+    get_log_nvidia_loaded_modules,
+    get_log_tegra_release,
+    get_log_boot_cmdline,
+    get_log_systemctl_failed,
+)
+
+logger = logging.getLogger(__name__)
+
+# Each entry: (filename for the .txt in the archive, getter function)
+# The command string comes from the getter's return value — single source of truth.
+LOG_ENTRIES: list[tuple[str, Callable]] = [
+    ("secure_boot_state.txt", get_log_secure_boot_state),
+    ("modinfo_host1x.txt", get_log_modinfo_host1x),
+    ("modinfo_tegra_drm.txt", get_log_modinfo_tegra_drm),
+    ("modinfo_nvgpu.txt", get_log_modinfo_nvgpu),
+    ("module_files_updates.txt", get_log_module_files_updates),
+    ("nvidia_modules_dep.txt", get_log_nvidia_modules_dep),
+    ("modprobe_nvidia.txt", get_log_modprobe_nvidia),
+    ("journalctl_current_boot.txt", get_log_journalctl_current_boot),
+    ("journalctl_all.txt", get_log_journalctl_all),
+    ("dmesg_all.txt", get_log_dmesg_all),
+    ("dmesg_nvidia_errors.txt", get_log_dmesg_nvidia_errors),
+    ("nvidia_rpms.txt", get_log_nvidia_rpms),
+    ("nvidia_loaded_modules.txt", get_log_nvidia_loaded_modules),
+    ("tegra_release.txt", get_log_tegra_release),
+    ("boot_cmdline.txt", get_log_boot_cmdline),
+    ("systemctl_failed.txt", get_log_systemctl_failed),
+]
+
+# internal functions
+
+def _format_log_content(command: str, exit_status: int, stdout: str, stderr: str) -> str:
+    """Format a single log entry as: command, blank line, then output/error/empty marker."""
+    if exit_status != 0:
+        error_detail = stderr if stderr else stdout if stdout else "no output"
+        return f"{command}\n\nCOMMAND FAILED (exit code {exit_status}): {error_detail}"
+    if not stdout:
+        return f"{command}\n\n-EMPTY OUTPUT-"
+    return f"{command}\n\n{stdout}"
+
+def _unique_archive_path(output_dir: Path, base_name: str) -> Path:
+    """Return a unique path for the archive, appending _1, _2, etc. if needed."""
+    candidate = output_dir / f"{base_name}.tar.gz"
+    if not candidate.exists():
+        return candidate
+    counter = 1
+    while True:
+        candidate = output_dir / f"{base_name}_{counter}.tar.gz"
+        if not candidate.exists():
+            return candidate
+        counter += 1
+
+# public functions
+
+def extract_build_id(bootc_image_url: Optional[str]) -> str:
+    """Extract the build ID (numbers after the final '-') from a bootc image URL.
+    Example: '...rhel97-5140-611381:6.2.2-5.14.0_611.38.1-032526102349' -> '032526102349'
+    Returns 'unknown' if URL is None or no match found."""
+    if not bootc_image_url:
+        return "unknown"
+    match = re.search(r"-(\d+)$", bootc_image_url)
+    return match.group(1) if match else "unknown"
+
+
+def collect_logs(ssh) -> list[tuple[str, str]]:
+    """Collect all device logs via SSH.
+    Returns list of (filename, formatted_content) tuples. Never skips entries."""
+    logs = []
+    # add hardware info to the logs as a dictionary
+    try:
+        dict_hardware_info = collect_hardware_info(ssh)
+    except Exception as e:
+        dict_hardware_info = "-Failed to collect hardware info-"
+    content = json.dumps(dict_hardware_info, indent=4)
+    logs.append(("general_hardware_info.json", content))
+    # add other logs to the logs
+    for filename, getter_fn in LOG_ENTRIES:
+        try:
+            command, exit_status, stdout, stderr = getter_fn(ssh)
+            content = _format_log_content(command, exit_status, stdout, stderr)
+        except Exception as e:
+            content = f"(unknown command)\n\nCOMMAND FAILED: {e}"
+        logs.append((filename, content))
+        logger.debug("Collected log: %s", filename)
+    return logs
+
+
+def create_logs_archive(
+    logs: list[tuple[str, str]],
+    bootc_image_url: Optional[str],
+    output_dir: Path,
+) -> Path:
+    """Create a tar.gz archive from collected logs.
+    Returns the Path to the created archive."""
+    build_id = extract_build_id(bootc_image_url)
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    base_name = f"device_logs_{date_str}_{build_id}"
+
+    os.makedirs(output_dir, exist_ok=True)
+    archive_path = _unique_archive_path(output_dir, base_name)
+
+    with tarfile.open(archive_path, "w:gz") as tar:
+        for filename, content in logs:
+            data = content.encode("utf-8")
+            info = tarfile.TarInfo(name=filename)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+
+    logger.info("Created device logs archive: %s", archive_path)
+    return archive_path
+
+
+def save_device_logs(
+    ssh,
+    bootc_image_url: Optional[str],
+    output_dir: Path,
+) -> Path:
+    """Collect all device logs and save as a tar.gz archive.
+    Returns the Path to the created archive."""
+    logs = collect_logs(ssh)
+    return create_logs_archive(logs, bootc_image_url, output_dir)

--- a/tests_resources/device_logs_collector.py
+++ b/tests_resources/device_logs_collector.py
@@ -16,50 +16,25 @@ from datetime import datetime
 from pathlib import Path
 from typing import Callable, Optional
 
-from tests_resources.hardware_info import (
-    collect as collect_hardware_info,
-    get_log_secure_boot_state,
-    get_log_modinfo_host1x,
-    get_log_modinfo_tegra_drm,
-    get_log_modinfo_nvgpu,
-    get_log_module_files_updates,
-    get_log_nvidia_modules_dep,
-    get_log_modprobe_nvidia,
-    get_log_journalctl_current_boot,
-    get_log_journalctl_all,
-    get_log_dmesg_all,
-    get_log_dmesg_nvidia_errors,
-    get_log_nvidia_rpms,
-    get_log_nvidia_loaded_modules,
-    get_log_tegra_release,
-    get_log_boot_cmdline,
-    get_log_systemctl_failed,
-)
+from tests_resources.hardware_info import collect as collect_hardware_info
 
 logger = logging.getLogger(__name__)
 
-# Each entry: (filename for the .txt in the archive, getter function)
-# The command string comes from the getter's return value — single source of truth.
-LOG_ENTRIES: list[tuple[str, Callable]] = [
-    ("secure_boot_state.txt", get_log_secure_boot_state),
-    ("modinfo_host1x.txt", get_log_modinfo_host1x),
-    ("modinfo_tegra_drm.txt", get_log_modinfo_tegra_drm),
-    ("modinfo_nvgpu.txt", get_log_modinfo_nvgpu),
-    ("module_files_updates.txt", get_log_module_files_updates),
-    ("nvidia_modules_dep.txt", get_log_nvidia_modules_dep),
-    ("modprobe_nvidia.txt", get_log_modprobe_nvidia),
-    ("journalctl_current_boot.txt", get_log_journalctl_current_boot),
-    ("journalctl_all.txt", get_log_journalctl_all),
-    ("dmesg_all.txt", get_log_dmesg_all),
-    ("dmesg_nvidia_errors.txt", get_log_dmesg_nvidia_errors),
-    ("nvidia_rpms.txt", get_log_nvidia_rpms),
-    ("nvidia_loaded_modules.txt", get_log_nvidia_loaded_modules),
-    ("tegra_release.txt", get_log_tegra_release),
-    ("boot_cmdline.txt", get_log_boot_cmdline),
-    ("systemctl_failed.txt", get_log_systemctl_failed),
-]
 
-# internal functions
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _run_log(ssh, command: str, timeout: int = 30, sudo: bool = False) -> tuple[str, int, str, str]:
+    """Run command for log collection. Returns (command, exit_status, stdout, stderr).
+    Raises RuntimeError on SSH/transport failures."""
+    try:
+        full_cmd = f"sudo {command}" if sudo else command
+        result = ssh.run(full_cmd, timeout=timeout, fail_on_rc=False, print_output=False)
+        return (command, result.exit_status, (result.stdout or "").strip(), (result.stderr or "").strip())
+    except (OSError, TimeoutError, EOFError) as e:
+        raise RuntimeError(f"SSH/transport error running '{command}': {e}")
+
 
 def _format_log_content(command: str, exit_status: int, stdout: str, stderr: str) -> str:
     """Format a single log entry as: command, blank line, then output/error/empty marker."""
@@ -69,6 +44,7 @@ def _format_log_content(command: str, exit_status: int, stdout: str, stderr: str
     if not stdout:
         return f"{command}\n\n-EMPTY OUTPUT-"
     return f"{command}\n\n{stdout}"
+
 
 def _unique_archive_path(output_dir: Path, base_name: str) -> Path:
     """Return a unique path for the archive, appending _1, _2, etc. if needed."""
@@ -82,9 +58,8 @@ def _unique_archive_path(output_dir: Path, base_name: str) -> Path:
             return candidate
         counter += 1
 
-# public functions
 
-def extract_build_id(bootc_image_url: Optional[str]) -> str:
+def _extract_build_id(bootc_image_url: Optional[str]) -> str:
     """Extract the build ID (numbers after the final '-') from a bootc image URL.
     Example: '...rhel97-5140-611381:6.2.2-5.14.0_611.38.1-032526102349' -> '032526102349'
     Returns 'unknown' if URL is None or no match found."""
@@ -94,37 +69,14 @@ def extract_build_id(bootc_image_url: Optional[str]) -> str:
     return match.group(1) if match else "unknown"
 
 
-def collect_logs(ssh) -> list[tuple[str, str]]:
-    """Collect all device logs via SSH.
-    Returns list of (filename, formatted_content) tuples. Never skips entries."""
-    logs = []
-    # add hardware info to the logs as a dictionary
-    try:
-        dict_hardware_info = collect_hardware_info(ssh)
-    except Exception as e:
-        dict_hardware_info = "-Failed to collect hardware info-"
-    content = json.dumps(dict_hardware_info, indent=4)
-    logs.append(("general_hardware_info.json", content))
-    # add other logs to the logs
-    for filename, getter_fn in LOG_ENTRIES:
-        try:
-            command, exit_status, stdout, stderr = getter_fn(ssh)
-            content = _format_log_content(command, exit_status, stdout, stderr)
-        except Exception as e:
-            content = f"(unknown command)\n\nCOMMAND FAILED: {e}"
-        logs.append((filename, content))
-        logger.debug("Collected log: %s", filename)
-    return logs
-
-
-def create_logs_archive(
+def _create_logs_archive(
     logs: list[tuple[str, str]],
     bootc_image_url: Optional[str],
     output_dir: Path,
 ) -> Path:
     """Create a tar.gz archive from collected logs.
     Returns the Path to the created archive."""
-    build_id = extract_build_id(bootc_image_url)
+    build_id = _extract_build_id(bootc_image_url)
     date_str = datetime.now().strftime("%Y-%m-%d")
     base_name = f"device_logs_{date_str}_{build_id}"
 
@@ -141,6 +93,95 @@ def create_logs_archive(
     logger.info("Created device logs archive: %s", archive_path)
     return archive_path
 
+# ---------------------------------------------------------------------------
+# Public functions
+# ---------------------------------------------------------------------------
+
+def get_log_secure_boot_state(ssh):
+    return _run_log(ssh, "mokutil --sb-state")
+
+
+def get_log_modinfo_host1x(ssh):
+    return _run_log(ssh, "modinfo host1x | head -5")
+
+
+def get_log_modinfo_tegra_drm(ssh):
+    return _run_log(ssh, "modinfo tegra_drm | head -5")
+
+
+def get_log_modinfo_nvgpu(ssh):
+    return _run_log(ssh, "modinfo nvgpu | head -5")
+
+
+def get_log_module_files_updates(ssh):
+    return _run_log(ssh, "ls -la /lib/modules/$(uname -r)/updates/")
+
+
+def get_log_nvidia_modules_dep(ssh):
+    return _run_log(ssh, "grep nvidia /lib/modules/$(uname -r)/modules.dep")
+
+
+def get_log_modprobe_nvidia(ssh):
+    return _run_log(ssh, "modprobe -v nvidia 2>&1", sudo=True)
+
+
+def get_log_journalctl_current_boot(ssh):
+    return _run_log(ssh, "journalctl -b", timeout=120, sudo=True)
+
+
+def get_log_journalctl_all(ssh):
+    return _run_log(ssh, "journalctl", timeout=180, sudo=True)
+
+
+def get_log_dmesg_all(ssh):
+    return _run_log(ssh, "dmesg", timeout=60, sudo=True)
+
+
+def get_log_dmesg_nvidia_errors(ssh):
+    return _run_log(ssh, 'dmesg | grep -iE "module.*verif|signature|PKCS|nvidia|Unknown.symbol"', timeout=60, sudo=True)
+
+
+def get_log_nvidia_rpms(ssh):
+    return _run_log(ssh, "rpm -qa | grep -i nvidia")
+
+
+def get_log_nvidia_loaded_modules(ssh):
+    return _run_log(ssh, "lsmod | grep -i nvidia")
+
+
+def get_log_tegra_release(ssh):
+    return _run_log(ssh, "cat /etc/nv_tegra_release")
+
+
+def get_log_boot_cmdline(ssh):
+    return _run_log(ssh, "cat /proc/cmdline")
+
+
+def get_log_systemctl_failed(ssh):
+    return _run_log(ssh, "systemctl --failed")
+
+
+def collect_logs(ssh) -> list[tuple[str, str]]:
+    """Collect all device logs via SSH.
+    Returns list of (filename, formatted_content) tuples. Never skips entries."""
+    logs = []
+    # add hardware info to the logs as a JSON file
+    try:
+        dict_hardware_info = collect_hardware_info(ssh)
+    except Exception as e:
+        dict_hardware_info = "-Failed to collect hardware info-"
+    logs.append(("general_hardware_info.json", json.dumps(dict_hardware_info, indent=4)))
+    # add command logs
+    for filename, getter_fn in LOG_ENTRIES.items():
+        try:
+            command, exit_status, stdout, stderr = getter_fn(ssh)
+            content = _format_log_content(command, exit_status, stdout, stderr)
+        except Exception as e:
+            content = f"(unknown command)\n\nCOMMAND FAILED: {e}"
+        logs.append((filename, content))
+        logger.debug("Collected log: %s", filename)
+    return logs
+
 
 def save_device_logs(
     ssh,
@@ -150,4 +191,28 @@ def save_device_logs(
     """Collect all device logs and save as a tar.gz archive.
     Returns the Path to the created archive."""
     logs = collect_logs(ssh)
-    return create_logs_archive(logs, bootc_image_url, output_dir)
+    return _create_logs_archive(logs, bootc_image_url, output_dir)
+
+# ---------------------------------------------------------------------------
+# LOG_ENTRIES: {filename: getter_function}
+# The command string comes from the getter's return value — single source of truth.
+# ---------------------------------------------------------------------------
+
+LOG_ENTRIES: dict[str, Callable] = {
+    "secure_boot_state.txt": get_log_secure_boot_state,
+    "modinfo_host1x.txt": get_log_modinfo_host1x,
+    "modinfo_tegra_drm.txt": get_log_modinfo_tegra_drm,
+    "modinfo_nvgpu.txt": get_log_modinfo_nvgpu,
+    "module_files_updates.txt": get_log_module_files_updates,
+    "nvidia_modules_dep.txt": get_log_nvidia_modules_dep,
+    "modprobe_nvidia.txt": get_log_modprobe_nvidia,
+    "journalctl_current_boot.txt": get_log_journalctl_current_boot,
+    "journalctl_all.txt": get_log_journalctl_all,
+    "dmesg_all.txt": get_log_dmesg_all,
+    "dmesg_nvidia_errors.txt": get_log_dmesg_nvidia_errors,
+    "nvidia_rpms.txt": get_log_nvidia_rpms,
+    "nvidia_loaded_modules.txt": get_log_nvidia_loaded_modules,
+    "tegra_release.txt": get_log_tegra_release,
+    "boot_cmdline.txt": get_log_boot_cmdline,
+    "systemctl_failed.txt": get_log_systemctl_failed,
+}

--- a/tests_resources/hardware_info.py
+++ b/tests_resources/hardware_info.py
@@ -40,6 +40,15 @@ def _run_sudo(ssh, command: str, timeout: Optional[int] = 30) -> str:
         logger.debug("Command sudo %r failed: %s", command, e)
         return ""
 
+def _run_log(ssh, command: str, timeout: int = 30, sudo: bool = False) -> tuple[str, int, str, str]:
+    """Run command for log collection. Returns (command, exit_status, stdout, stderr).
+    Raises RuntimeError on SSH/transport failures."""
+    try:
+        full_cmd = f"sudo {command}" if sudo else command
+        result = ssh.run(full_cmd, timeout=timeout, fail_on_rc=False, print_output=False)
+        return (command, result.exit_status, (result.stdout or "").strip(), (result.stderr or "").strip())
+    except (OSError, TimeoutError, EOFError) as e:
+        raise RuntimeError(f"SSH/transport error running '{command}': {e}")
 
 def _parse_decimal(s: str) -> Optional[Union[float, str]]:
     """
@@ -281,6 +290,7 @@ def collect(ssh) -> dict[str, Any]:
     l4t = get_l4t_version(ssh)
     userspace = get_jetpack_userspace_version(ssh)
     kmod = get_jetpack_kmod_version(ssh)
+    secure_boot_state = get_log_secure_boot_state(ssh)
 
     return {
         "rhel_version": get_rhel_version(ssh),
@@ -297,4 +307,73 @@ def collect(ssh) -> dict[str, Any]:
         "bootc_version": bootc["bootc_version"],
         "bootc_image_url": bootc["bootc_image_url"],
         "bootc_image_version": bootc["bootc_image_version"],
+        "secure_boot_state": secure_boot_state[2].splitlines()[0].split(" ")[1].strip() if secure_boot_state[2] else None,
     }
+
+# ---------------------------------------------------------------------------
+# Log-fetching functions for device diagnostics (used by _run_log)
+# Each returns (command, exit_status, stdout, stderr).
+# ---------------------------------------------------------------------------
+
+def get_log_secure_boot_state(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "mokutil --sb-state")
+
+
+def get_log_modinfo_host1x(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "modinfo host1x | head -5")
+
+
+def get_log_modinfo_tegra_drm(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "modinfo tegra_drm | head -5")
+
+
+def get_log_modinfo_nvgpu(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "modinfo nvgpu | head -5")
+
+
+def get_log_module_files_updates(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "ls -la /lib/modules/$(uname -r)/updates/")
+
+
+def get_log_nvidia_modules_dep(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "grep nvidia /lib/modules/$(uname -r)/modules.dep")
+
+
+def get_log_modprobe_nvidia(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "modprobe -v nvidia 2>&1", sudo=True)
+
+
+def get_log_journalctl_current_boot(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "journalctl -b", timeout=120, sudo=True)
+
+
+def get_log_journalctl_all(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "journalctl", timeout=180, sudo=True)
+
+
+def get_log_dmesg_all(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "dmesg", timeout=60, sudo=True)
+
+
+def get_log_dmesg_nvidia_errors(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "dmesg | grep -iE \"module.*verif|signature|PKCS|nvidia|Unknown.symbol\"", timeout=60, sudo=True)
+
+
+def get_log_nvidia_rpms(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "rpm -qa | grep -i nvidia")
+
+
+def get_log_nvidia_loaded_modules(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "lsmod | grep -i nvidia")
+
+
+def get_log_tegra_release(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "cat /etc/nv_tegra_release")
+
+
+def get_log_boot_cmdline(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "cat /proc/cmdline")
+
+
+def get_log_systemctl_failed(ssh) -> tuple[str, int, str, str]:
+    return _run_log(ssh, "systemctl --failed")

--- a/tests_resources/hardware_info.py
+++ b/tests_resources/hardware_info.py
@@ -40,15 +40,6 @@ def _run_sudo(ssh, command: str, timeout: Optional[int] = 30) -> str:
         logger.debug("Command sudo %r failed: %s", command, e)
         return ""
 
-def _run_log(ssh, command: str, timeout: int = 30, sudo: bool = False) -> tuple[str, int, str, str]:
-    """Run command for log collection. Returns (command, exit_status, stdout, stderr).
-    Raises RuntimeError on SSH/transport failures."""
-    try:
-        full_cmd = f"sudo {command}" if sudo else command
-        result = ssh.run(full_cmd, timeout=timeout, fail_on_rc=False, print_output=False)
-        return (command, result.exit_status, (result.stdout or "").strip(), (result.stderr or "").strip())
-    except (OSError, TimeoutError, EOFError) as e:
-        raise RuntimeError(f"SSH/transport error running '{command}': {e}")
 
 def _parse_decimal(s: str) -> Optional[Union[float, str]]:
     """
@@ -89,10 +80,14 @@ def get_rhel_version(ssh) -> Optional[str]:
     return match.group(1) if match else None
 
 
+def get_tegra_release(ssh) -> str:
+    return _run(ssh, "cat /etc/nv_tegra_release")
+
+
 def get_l4t_version(ssh) -> Optional[Union[float, str]]:
     """Return L4T version from /etc/nv_tegra_release (e.g. '36.5.0').
     Returns str for X.Y.Z, float for X.Y, or None."""
-    jetpack_raw = _run(ssh, "head -n 1 /etc/nv_tegra_release")
+    jetpack_raw = get_tegra_release(ssh).splitlines()[0]
     if not jetpack_raw:
         return None
 
@@ -260,6 +255,13 @@ def get_bootc_info(ssh) -> dict[str, Any]:
     return info
 
 
+def get_secure_boot_state(ssh) -> str:
+    state = _run(ssh, "mokutil --sb-state").splitlines()[0].split(" ")[1].strip()
+    if state == "":
+        raise ValueError("Failed to get secure boot state")
+    return state
+
+
 def collect(ssh) -> dict[str, Any]:
     """
     Collect all hardware and system info from the remote host via SSH.
@@ -290,7 +292,7 @@ def collect(ssh) -> dict[str, Any]:
     l4t = get_l4t_version(ssh)
     userspace = get_jetpack_userspace_version(ssh)
     kmod = get_jetpack_kmod_version(ssh)
-    secure_boot_state = get_log_secure_boot_state(ssh)
+    secure_boot_state = get_secure_boot_state(ssh)
 
     return {
         "rhel_version": get_rhel_version(ssh),
@@ -307,73 +309,6 @@ def collect(ssh) -> dict[str, Any]:
         "bootc_version": bootc["bootc_version"],
         "bootc_image_url": bootc["bootc_image_url"],
         "bootc_image_version": bootc["bootc_image_version"],
-        "secure_boot_state": secure_boot_state[2].splitlines()[0].split(" ")[1].strip() if secure_boot_state[2] else None,
+        "secure_boot_state": secure_boot_state,
     }
-
-# ---------------------------------------------------------------------------
-# Log-fetching functions for device diagnostics (used by _run_log)
-# Each returns (command, exit_status, stdout, stderr).
-# ---------------------------------------------------------------------------
-
-def get_log_secure_boot_state(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "mokutil --sb-state")
-
-
-def get_log_modinfo_host1x(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "modinfo host1x | head -5")
-
-
-def get_log_modinfo_tegra_drm(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "modinfo tegra_drm | head -5")
-
-
-def get_log_modinfo_nvgpu(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "modinfo nvgpu | head -5")
-
-
-def get_log_module_files_updates(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "ls -la /lib/modules/$(uname -r)/updates/")
-
-
-def get_log_nvidia_modules_dep(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "grep nvidia /lib/modules/$(uname -r)/modules.dep")
-
-
-def get_log_modprobe_nvidia(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "modprobe -v nvidia 2>&1", sudo=True)
-
-
-def get_log_journalctl_current_boot(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "journalctl -b", timeout=120, sudo=True)
-
-
-def get_log_journalctl_all(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "journalctl", timeout=180, sudo=True)
-
-
-def get_log_dmesg_all(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "dmesg", timeout=60, sudo=True)
-
-
-def get_log_dmesg_nvidia_errors(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "dmesg | grep -iE \"module.*verif|signature|PKCS|nvidia|Unknown.symbol\"", timeout=60, sudo=True)
-
-
-def get_log_nvidia_rpms(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "rpm -qa | grep -i nvidia")
-
-
-def get_log_nvidia_loaded_modules(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "lsmod | grep -i nvidia")
-
-
-def get_log_tegra_release(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "cat /etc/nv_tegra_release")
-
-
-def get_log_boot_cmdline(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "cat /proc/cmdline")
-
-
-def get_log_systemctl_failed(ssh) -> tuple[str, int, str, str]:
-    return _run_log(ssh, "systemctl --failed")
+    

--- a/tests_suites/conftest.py
+++ b/tests_suites/conftest.py
@@ -71,6 +71,7 @@ BOOTC_AVAILABLE: bool = False
 BOOTC_VERSION: Optional[Union[float, str]] = None  # str if X.Y.Z, float if X.Y
 BOOTC_IMAGE_VERSION: Optional[Union[str]] = None
 BOOTC_IMAGE_URL: Optional[str] = None
+SECURE_BOOT_STATE: Optional[str] = None
 
 if JETSON_KEY_PATH: # key path provided, use key-based authentication
     key_path = os.path.expanduser(JETSON_KEY_PATH)
@@ -106,7 +107,7 @@ def _install_beaker_repo(ssh, rhel_version: Optional[str]):
     RHEL version is required to install the correct Beaker repository.
     Retries DNF operations up to 3 times to handle transient mirror failures.
     """
-    logger.info("Checking Beaker repositories exist on the Jetson...")
+    logger.info("[Setup] Checking Beaker repositories exist on the Jetson...")
     if rhel_version is None:
         raise ValueError("RHEL version not found, The environment is not a RHEL machine")
 
@@ -118,10 +119,10 @@ def _install_beaker_repo(ssh, rhel_version: Optional[str]):
     
     result = ssh.sudo("dnf repolist | grep beaker- | wc -l")
     if result.exit_status == 0 and int(result.stdout.strip()) >= 12:
-        logger.info("installing EPEL release for RHEL %s", rhel_version)
+        logger.info("[Setup] installing EPEL release for RHEL %s", rhel_version)
         ssh.sudo(cmd_epel)
     else:
-      logger.info("installing Beaker repositories and EPEL release for RHEL %s", rhel_version)
+      logger.info("[Setup] installing Beaker repositories and EPEL release for RHEL %s", rhel_version)
       for attempt in range(1, 4):
           try:
               ssh.sudo(cmd_appstream)
@@ -179,6 +180,16 @@ def get_hardware_spec(hardware_model_name: Optional[str]) -> Optional[Dict[str, 
                 return spec
     return None
 
+def fetch_hardware_logs(ssh):
+    """
+    Fetch hardware logs and outputs from the Jetson.
+    Logs and outputs are saved to qe-rhel-jetson/device_logs/ as a tar.gz archive.
+    """
+    from tests_resources.device_logs_collector import save_device_logs
+    output_dir = Path(__file__).parent.parent / "device_logs"
+    archive_path = save_device_logs(ssh, BOOTC_IMAGE_URL, output_dir)
+    logger.info("[Teardown] Device logs saved to: %s", archive_path)
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -208,6 +219,7 @@ def hardware_info_session():
     global FIRMWARE_VERSION, FIRMWARE_TYPE
     global HARDWARE_MODEL_NAME, KERNEL_VERSION, CPU_ARCH
     global BOOTC_AVAILABLE, BOOTC_VERSION, BOOTC_IMAGE_URL, BOOTC_IMAGE_VERSION
+    global SECURE_BOOT_STATE
     RHEL_VERSION = info.get("rhel_version")
     L4T_VERSION = info.get("l4t_version")
     JETPACK_VERSION = info.get("jetpack_version")
@@ -221,7 +233,7 @@ def hardware_info_session():
     BOOTC_VERSION = info.get("bootc_version")
     BOOTC_IMAGE_VERSION = info.get("bootc_image_version")
     BOOTC_IMAGE_URL = info.get("bootc_image_url")
-
+    SECURE_BOOT_STATE = info.get("secure_boot_state")
     # Skip entire session if hardware model is not in Testing Matrix (jetson_hardware_specs.yaml)
     if get_hardware_spec(HARDWARE_MODEL_NAME) is None:
         pytest.skip(
@@ -256,10 +268,11 @@ def hardware_info_session():
     print(f"4. JetPack version (RPM):    {JETPACK_VERSION}")
     print(f"5. JetPack kmod (RPM):       {JETPACK_KMOD_VERSION}")
     print(f"6. Firmware type/version:    {FIRMWARE_TYPE}{fw_ver}")
+    print(f"7. Secure boot state:        {SECURE_BOOT_STATE}")
     print("=" * 80)
-    print(f"7. Bootc available:          {BOOTC_AVAILABLE}")
-    print(f"8. Bootc image version:      {BOOTC_IMAGE_VERSION}")
-    print(f"9. Bootc image URL:          {BOOTC_IMAGE_URL}")
+    print(f"8. Bootc available:          {BOOTC_AVAILABLE}")
+    print(f"9. Bootc image version:      {BOOTC_IMAGE_VERSION}")
+    print(f"10. Bootc image URL:          {BOOTC_IMAGE_URL}")
     print("=" * 80 + "\n")
     yield
 
@@ -280,6 +293,26 @@ def beaker_repo_session(hardware_info_session):
         _install_beaker_repo(ssh, RHEL_VERSION)
     yield
 
+@pytest.fixture(scope="session", autouse=True)
+def fetch_hardware_logs_session(hardware_info_session):
+    """
+    Fetch hardware logs and outputs from the Jetson at session teardown.
+    Depends on hardware_info_session to ensure BOOTC_IMAGE_URL is available.
+    Logs are saved to qe-rhel-jetson/device_logs/ as a tar.gz archive.
+    """
+    yield
+    logger.info("[Teardown] Fetching hardware logs from the Jetson...")
+    with SSHConnection(
+        JETSON_HOST,
+        JETSON_USERNAME,
+        JETSON_PASSWORD or None,
+        JETSON_PORT,
+        JETSON_TIMEOUT,
+        key_filename=key_path,
+    ) as ssh:
+        fetch_hardware_logs(ssh)
+    logger.info("[Teardown] Hardware logs fetched successfully")
+
 @pytest.fixture(scope="class")
 def ssh():
     """
@@ -295,7 +328,7 @@ def ssh():
     hardware information at the beginning of the test session.
     """
     logger.info(
-        "[conftest] Using JETSON_HOST=%s JETSON_PORT=%s JETSON_USERNAME=%s JETSON_TIMEOUT=%s",
+        "[SSH Fixture] Using JETSON_HOST=%s JETSON_PORT=%s JETSON_USERNAME=%s JETSON_TIMEOUT=%s",
         JETSON_HOST, JETSON_PORT, JETSON_USERNAME, JETSON_TIMEOUT,
     )
     key_path = os.path.expanduser(JETSON_KEY_PATH) if JETSON_KEY_PATH else None
@@ -322,7 +355,7 @@ def ssh():
             f"  - Firewall allows SSH connections\n"
             f"  - Network connectivity is available"
         )
-        logger.error(f"\n[conftest] {error_msg}\n")
+        logger.error(f"\n[SSH Fixture] {error_msg}\n")
         raise
 
 


### PR DESCRIPTION
(1) create device_logs_collectoer.py resource file which have functions for createing tar file and collect logs. 
(2) add functions into hardware_info.py resource file for collecting logs (using by _run_log helper) 
(3) add fetch_hardware_logs_session fixture to run in the end of the session for fetching logs and outputs 
(4) add git ignore for /device_logs directory
(!) the code create tar gz file with filename including current date and baseURL ID of the BootC image, and save hime under /device_logs 
(!) IF the same name existing already , the code add +1 in the end of the filename