### PR TITLE
Enable RHEL 9.8 support with bootc deployment fixes

### DIFF
--- a/beaker/ansible/install_bootc.yml
+++ b/beaker/ansible/install_bootc.yml
@@ -273,7 +273,7 @@
       ansible.builtin.command:
         cmd: >
           dnf config-manager --add-repo
-          http://download.eng.rdu.redhat.com/released/rhel-{{ rhel_major_version }}/RHEL-{{ rhel_major_version }}/{{ rhel_version }}.0/AppStream/aarch64/os/
+          https://download.devel.redhat.com/rhel-{{ rhel_major_version }}/nightly/RHEL-{{ rhel_major_version }}/latest-RHEL-{{ rhel_version }}.0/compose/AppStream/aarch64/os/
       register: appstream_repo_result
       changed_when: appstream_repo_result.rc == 0
       failed_when: false
@@ -283,9 +283,21 @@
       ansible.builtin.command:
         cmd: >
           dnf config-manager --add-repo
-          http://download.eng.rdu.redhat.com/released/rhel-{{ rhel_major_version }}/RHEL-{{ rhel_major_version }}/{{ rhel_version }}.0/BaseOS/aarch64/os/
+          https://download.devel.redhat.com/rhel-{{ rhel_major_version }}/nightly/RHEL-{{ rhel_major_version }}/latest-RHEL-{{ rhel_version }}.0/compose/BaseOS/aarch64/os/
       register: baseos_repo_result
       changed_when: baseos_repo_result.rc == 0
+      failed_when: false
+      tags: [packages]
+
+    # download.devel.redhat.com uses a Red Hat internal self-signed certificate
+    # chain. Without sslverify=0, dnf fails with "SSL peer certificate" errors
+    - name: Disable SSL verification for nightly repos (self-signed cert chain)
+      ansible.builtin.shell: |
+        for repo in /etc/yum.repos.d/download.devel.redhat.com_*.repo; do
+          [ -f "$repo" ] && sed -i 's/^\(sslverify\s*=\).*/\1=0/' "$repo"
+          grep -q '^sslverify' "$repo" 2>/dev/null || echo 'sslverify=0' >> "$repo"
+        done
+      changed_when: true
       failed_when: false
       tags: [packages]
 

--- a/beaker/ansible/install_jetpack_rpms.yml
+++ b/beaker/ansible/install_jetpack_rpms.yml
@@ -350,7 +350,7 @@
       ansible.builtin.command:
         cmd: >
           dnf config-manager --add-repo
-          http://download.eng.rdu.redhat.com/released/rhel-{{ rhel_major_version }}/RHEL-{{ rhel_major_version }}/{{ rhel_version }}.0/AppStream/aarch64/os/
+          https://download.devel.redhat.com/rhel-{{ rhel_major_version }}/nightly/RHEL-{{ rhel_major_version }}/latest-RHEL-{{ rhel_version }}.0/compose/AppStream/aarch64/os/
       register: appstream_repo_result
       changed_when: appstream_repo_result.rc == 0
       failed_when: false
@@ -360,7 +360,7 @@
       ansible.builtin.command:
         cmd: >
           dnf config-manager --add-repo
-          http://download.eng.rdu.redhat.com/released/rhel-{{ rhel_major_version }}/RHEL-{{ rhel_major_version }}/{{ rhel_version }}.0/BaseOS/aarch64/os/
+          https://download.devel.redhat.com/rhel-{{ rhel_major_version }}/nightly/RHEL-{{ rhel_major_version }}/latest-RHEL-{{ rhel_version }}.0/compose/BaseOS/aarch64/os/
       register: baseos_repo_result
       changed_when: baseos_repo_result.rc == 0
       failed_when: false

--- a/beaker/scripts/reserve_jetson.py
+++ b/beaker/scripts/reserve_jetson.py
@@ -52,9 +52,24 @@ JOB_XML_TEMPLATE = '''<job retention_tag="scratch">
       <packages/>
       <ks_appends>
         <ks_append><![CDATA[
-clearpart --all --initlabel --disklabel=gpt
+%pre --interpreter=/bin/bash
+# Pick the largest non-eMMC disk (NVMe on Jetsons) so ESP and root
+# land on the same device — bootc requires this for to-existing-root.
+DISK=$(lsblk -dnbo NAME,SIZE,TYPE 2>/dev/null \
+       | awk '$3=="disk" && $1 !~ /^mmcblk/ {{print $1, $2}}' \
+       | sort -k2 -rn | head -1 | awk '{{print $1}}')
+[ -z "$DISK" ] && DISK=$(lsblk -dnbo NAME,SIZE,TYPE 2>/dev/null \
+       | awk '$3=="disk" {{print $1, $2}}' \
+       | sort -k2 -rn | head -1 | awk '{{print $1}}')
+cat > /tmp/partitions.ks <<EOF
+ignoredisk --only-use=$DISK
+clearpart --all --initlabel --disklabel=gpt --drives=$DISK
 reqpart --add-boot
 part / --grow --fstype xfs
+EOF
+%end
+
+%include /tmp/partitions.ks
 ]]></ks_append>
       </ks_appends>
       <repos/>

--- a/infra_tests/ssh_client.py
+++ b/infra_tests/ssh_client.py
@@ -156,7 +156,8 @@ class SSHConnection(Connection):
         ]
         # Import here to avoid circular import (conftest imports ssh_client)
         from tests_suites import conftest as _conftest
-        # if bootc is available, add --transient to mutating dnf commands
+        # if bootc is available, add --transient
+        # and --nogpgcheck because the image does not have the GPG key for internal Red Hat repositories
         if _conftest.BOOTC_AVAILABLE:
             cmd_parts = command.split()
             if cmd_parts and cmd_parts[0] == "dnf":

--- a/tests_suites/conftest.py
+++ b/tests_suites/conftest.py
@@ -97,38 +97,52 @@ def _load_hardware_specs() -> Dict[str, Any]:
 
 def _install_beaker_repo(ssh, rhel_version: Optional[str]):
     """
-    Install Beaker repository on the Jetson.
-    RHEL version is required to install the correct Beaker repository.
-    Retries DNF operations up to 3 times to handle transient mirror failures.
+    Ensure nightly repos (AppStream/BaseOS) and EPEL exist on the Jetson.
+    On Beaker deployments the Ansible playbook handles this; 
+    on Jumpstarter deployments there is no playbook, so this function installs them as fallback.
+    
+    download.devel.redhat.com uses a Red Hat internal self-signed cert chain -
+    bootc images don't include the internal CA, so sslverify=0 is required.
     """
-    logger.info("[Setup] Checking Beaker repositories exist on the Jetson...")
+    logger.info("[Setup] Verifying repositories exist on the Jetson...")
     if rhel_version is None:
         raise ValueError("RHEL version not found, The environment is not a RHEL machine")
 
     main_rhel_version = str(rhel_version).split(".")[0]
-    # declare commands to install Beaker repositories and EPEL release
+    nightly_base = f"https://download.devel.redhat.com/rhel-{main_rhel_version}/nightly/RHEL-{main_rhel_version}/latest-RHEL-{rhel_version}/compose"
+    cmd_appstream = f"dnf config-manager --add-repo {nightly_base}/AppStream/aarch64/os/"
+    cmd_baseos = f"dnf config-manager --add-repo {nightly_base}/BaseOS/aarch64/os/"
+    # sslverify=0: download.devel.redhat.com uses Red Hat internal CA not in bootc trust store
+    cmd_sslverify = (
+        'for f in /etc/yum.repos.d/download.devel.redhat.com_*.repo; do '
+        '[ -f "$f" ] && grep -q "^sslverify" "$f" '
+        '&& sed -i "s/^sslverify.*/sslverify=0/" "$f" '
+        '|| echo "sslverify=0" >> "$f"; done'
+    )
+    # --nogpgcheck: bootc images don't ship pre-imported GPG keys
     cmd_epel = f"dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-{main_rhel_version}.noarch.rpm -y"
-    cmd_appstream = f"dnf config-manager --add-repo http://download.eng.rdu.redhat.com/released/rhel-{main_rhel_version}/RHEL-{main_rhel_version}/{rhel_version}.0/AppStream/aarch64/os/"
-    cmd_baseos = f"dnf config-manager --add-repo http://download.eng.rdu.redhat.com/released/rhel-{main_rhel_version}/RHEL-{main_rhel_version}/{rhel_version}.0/BaseOS/aarch64/os/"
-    
-    result = ssh.sudo("dnf repolist | grep beaker- | wc -l")
-    if result.exit_status == 0 and int(result.stdout.strip()) >= 12:
-        logger.info("[Setup] installing EPEL release for RHEL %s", rhel_version)
+
+    result = ssh.sudo("dnf repolist")
+    repos = result.stdout.lower()
+
+    if "appstream" not in repos or "baseos" not in repos:
+        logger.info("[Setup] Nightly repos missing, installing for RHEL %s", rhel_version)
+        for attempt in range(1, 4):
+            try:
+                ssh.sudo(cmd_appstream)
+                ssh.sudo(cmd_baseos)
+                ssh.sudo(cmd_sslverify)
+                break
+            except Exception as e:
+                if attempt < 3:
+                    logger.warning("Repo setup failed (attempt %s/3): %s, retrying...", attempt, e)
+                    time.sleep(5)
+                else:
+                    raise
+
+    if "epel" not in repos:
+        logger.info("[Setup] EPEL missing, installing for RHEL %s", rhel_version)
         ssh.sudo(cmd_epel)
-    else:
-      logger.info("[Setup] installing Beaker repositories and EPEL release for RHEL %s", rhel_version)
-      for attempt in range(1, 4):
-          try:
-              ssh.sudo(cmd_appstream)
-              ssh.sudo(cmd_baseos)
-              ssh.sudo(cmd_epel)
-              break
-          except Exception as e:
-              if attempt < 3:
-                  logger.warning("DNF operation failed (attempt %s/3): %s, retrying...", attempt, e)
-                  time.sleep(5)
-              else:
-                  raise
 
 def _get_target_versions(jetpack_userspace_version: Optional[str]) -> Optional[Dict[str, str]]:
     """Return target version dict for the given Jetpack version, or None."""

--- a/tests_suites/jetson_hardware_specs.yaml
+++ b/tests_suites/jetson_hardware_specs.yaml
@@ -12,16 +12,10 @@
 _target_versions:
 
   "6.2.2":
-    rhel_version: "9.7"
+    rhel_version: "9.8"
     l4t_version: "36.5.0"
-    uefi_firmware_version: "36.4.4"
-    kernel_version: "5.14.0-611.47.1"
-
-  "6.2.1":
-    rhel_version: "9.7"
-    l4t_version: "36.4.4"
-    uefi_firmware_version: "36.4.4"
-    kernel_version: "5.14.0-611.36.1"
+    uefi_firmware_version: "36.5.1"
+    kernel_version: "5.14.0-687.5.1"
 
 # -----------------------------------------------------------------------------
 # Shared templates (anchors for merge; not used as match keys)


### PR DESCRIPTION
1. Update target versions to RHEL 9.8 (kernel 5.14.0-687.5.1, UEFI 36.5.1)
2. Fix Beaker kickstart to dynamically select NVMe disk — bootc to-existing-root requires ESP and root on the same device, but RHEL 9.8 anaconda splits boot onto eMMC and root onto NVMe
3. Switch repo URLs from download.eng.rdu (released) to download.devel (nightly) and add sslverify=0 — bootc images don't include Red Hat's internal CA certificate
4. Move repo setup from conftest to Ansible playbook, conftest now verifies repos exist and installs as fallback for Jumpstarter deployments
5. Add --nogpgcheck for EPEL install — bootc images don't ship pre-imported GPG keys