### PR TITLE
Add GUI-enabled disk image build and VNC remote desktop support

### DIFF
--- a/jumpstarter/Containerfile-gui
+++ b/jumpstarter/Containerfile-gui
@@ -1,0 +1,26 @@
+ARG BASE_IMAGE=quay.io/redhat-user-workloads/jetpack-for-rhel-tenant/rhel97-5140-611421-stage:6.2.2-5.14.0_611.42.1-032626145744
+ARG RHEL_VERSION=9.7
+
+FROM ${BASE_IMAGE}
+
+ARG RHEL_VERSION
+
+RUN dnf config-manager --add-repo https://download.devel.redhat.com/rhel-${RHEL_VERSION%%.*}/nightly/RHEL-${RHEL_VERSION%%.*}/latest-RHEL-${RHEL_VERSION}.0/compose/BaseOS/aarch64/os/ && \
+    dnf config-manager --add-repo https://download.devel.redhat.com/rhel-${RHEL_VERSION%%.*}/nightly/RHEL-${RHEL_VERSION%%.*}/latest-RHEL-${RHEL_VERSION}.0/compose/AppStream/aarch64/os/ && \
+    for repo in /etc/yum.repos.d/download.devel.redhat.com_*.repo; do \
+      echo -e "sslverify=0\ngpgcheck=0" >> "$repo"; \
+    done && \
+    dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${RHEL_VERSION%%.*}.noarch.rpm
+
+RUN dnf install -y --nogpgcheck \
+    gdm \
+    gnome-shell \
+    gnome-control-center \
+    nautilus \
+    xorg-x11-drivers \
+    x11vnc \
+    && dnf clean all
+
+RUN usermod -aG video gdm
+
+RUN systemctl set-default graphical.target

--- a/jumpstarter/README.md
+++ b/jumpstarter/README.md
@@ -180,6 +180,101 @@ pytest tests_suites/
 
 ---
 
+## Optional: Build a GUI-Enabled Disk Image
+
+By default, the bootc not including GNOME desktop packages. To build a disk image with GNOME desktop (GDM + gnome-shell) for display testing or KVM usage, use `Containerfile-gui`:
+
+### 1. Build the GUI container image
+
+```bash
+# Default (RHEL 9.7 with default base image):
+podman build --platform linux/arm64 -t localhost/jetson-gui:latest -f Containerfile-gui .
+
+# Custom base image and/or RHEL version:
+podman build --platform linux/arm64 \
+  --build-arg BASE_IMAGE=<your-base-image> \
+  --build-arg RHEL_VERSION=9.8 \
+  -t localhost/jetson-gui:latest -f Containerfile-gui .
+```
+
+| Build arg | Default | Description |
+|-----------|---------|-------------|
+| `BASE_IMAGE` | `quay.io/.../rhel97-5140-611421-stage:...` | Base bootc image to layer GUI on top of |
+| `RHEL_VERSION` | `9.7` | RHEL version for repo URLs and EPEL |
+
+> **Note:** `Containerfile-gui` layers GDM, gnome-shell, x11vnc, and xorg-x11-drivers on top of the base image.
+
+### 2. Build the raw disk image
+
+```bash
+mkdir -p ./output && sudo chmod 777 ./output
+
+podman run --rm --privileged \
+  --security-opt label=type:unconfined_t \
+  -v /var/lib/containers/storage:/var/lib/containers/storage \
+  -v ./config.toml:/config.toml:ro \
+  -v ./output:/output \
+  registry.redhat.io/rhel9/bootc-image-builder:latest build \
+  --output /output --type raw --target-arch arm64 \
+  localhost/jetson-gui:latest
+```
+
+### 3. Compress and flash
+
+```bash
+xz ./output/image/disk.raw
+export DISK_IMAGE_PATH="$(pwd)/output/image/disk.raw.xz"
+```
+ 
+Then flash and run tests as usual (see Step 2 and Step 3 above).
+
+### Display Output Notes
+
+- The nvidia driver on AGX Orin exposes a single DRM connector: `card1-DP-1` (DisplayPort)
+- GDM renders to this connector at 1920x1080
+- GDM uses `-displayfd` so verify display number with:
+  ```bash
+  cat /proc/$(pgrep -o gnome-shell)/environ | tr '\0' '\n' | grep DISPLAY
+  ```
+
+### VNC Remote Desktop Access
+
+If the KVM shows a black screen after boot, use VNC to access the GNOME desktop remotely.
+
+**On the device** (transient install, lost on reboot):
+
+```bash
+# 1. Install EPEL and x11vnc (should be hundled by the jumpstarter/Containerfile-gui)
+dnf install --transient -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+dnf install --transient -y x11vnc
+
+# 2. Find the actual display number and Xauthority path
+export XDISPLAY=$(cat /proc/$(pgrep -o gnome-shell)/environ | tr '\0' '\n' | grep DISPLAY | cut -d= -f2)
+export XAUTH=$(ps aux | grep Xorg | grep -oP '(?<=-auth )\S+')
+
+# 3. Start x11vnc
+x11vnc -display $XDISPLAY -auth $XAUTH -forever -noshm -passwd $JETSON_PASSWORD -rfbport 5900 &
+```
+-> **Note:** example : x11vnc -display $XDISPLAY -auth $XAUTH -forever -noshm -passwd 123 -rfbport 5900 &
+
+**From your local machine** (SSH tunnel + VNC client):
+
+```bash
+# Terminal 1: SSH tunnel
+ssh -L 5900:localhost:5900 root@<device-hostname>
+
+# Terminal 2: Connect VNC
+# Mac:
+open vnc://localhost:5900
+# Linux:
+vncviewer localhost:5900
+```
+
+> **Note:** The Xauthority path is `/run/user/0/gdm/Xauthority` (uid 0 = root).
+> Direct VNC without SSH tunnel may fail if port 5900 is firewalled.
+
+---
+
 ## What wrapper.py Does
 
 1. Connects storage to DUT and power-cycles the device


### PR DESCRIPTION
1. Add Containerfile-gui that layers GDM, gnome-shell, x11vnc, and xorg-x11-drivers on any bootc base image with parameterized BASE_IMAGE and RHEL_VERSION build args
2. Add README section for building GUI disk images with build-arg examples and a table of available options
3. Add VNC remote desktop instructions with auto-detection of display number and Xauthority path for reliable x11vnc startup
4. Document display output behavior on AGX Orin (card1-DP-1 connector)