### PR TITLE
Fix wrapper boot stability and add memory cache cleanup between tests

### DIFF
--- a/jumpstarter/wrapper.py
+++ b/jumpstarter/wrapper.py
@@ -255,15 +255,21 @@ with env() as client:
         for boot_attempt in range(MAX_WRONG_OS_RETRIES + 1):
             wrong_os = False
 
+            # Power on first so the storage controller is active, connect storage
+            # to DUT, then power off cleanly before the real boot.
+            client.power.on()
+            logger.info("[wrapper] DUT powered on (pre-storage)")
+            client.storage.dut()
+            logger.info("[wrapper] Storage connected to DUT")
+            client.power.off()
+            logger.info("[wrapper] DUT powered off (storage attached)")
+
             if force_nvme_boot:
                 logger.info("[wrapper] Skipping storage.dut() — forcing NVMe boot to fix EFI entries")
                 force_nvme_boot = False
-            else:
-                client.storage.dut()
-                logger.info("[wrapper] Storage connected to DUT")
 
-            client.power.cycle()
-            logger.info("[wrapper] DUT powered on")
+            client.power.on()
+            logger.info("[wrapper] DUT powered on (booting)")
 
             with client.serial.pexpect() as p:
                 p.logfile = sys.stdout.buffer
@@ -305,13 +311,18 @@ with env() as client:
 
                 else:
                     # Correct OS — proceed with SSH configuration
-                    p.sendline("")
-                    p.expect_exact("login:", timeout=30)
                     logger.info("[wrapper] Successfully showing login prompt via console")
 
                     if PASSWORD:
                         logger.info("[wrapper] Configuring SSH root password login via serial console...")
-                        time.sleep(2)
+                        time.sleep(5)
+                        # Flush any stale login prompts from buffer
+                        try:
+                            while True:
+                                p.read_nonblocking(size=4096, timeout=1)
+                        except Exception:
+                            pass
+                        # Send Enter to get a single clean login prompt
                         p.sendline("")
                         p.expect_exact("login:", timeout=30)
                         p.sendline(USERNAME)

--- a/jumpstarter/wrapper.py
+++ b/jumpstarter/wrapper.py
@@ -255,21 +255,18 @@ with env() as client:
         for boot_attempt in range(MAX_WRONG_OS_RETRIES + 1):
             wrong_os = False
 
-            # Power on first so the storage controller is active, connect storage
-            # to DUT, then power off cleanly before the real boot.
-            client.power.on()
-            logger.info("[wrapper] DUT powered on (pre-storage)")
-            client.storage.dut()
-            logger.info("[wrapper] Storage connected to DUT")
             client.power.off()
-            logger.info("[wrapper] DUT powered off (storage attached)")
+            logger.info("[wrapper] DUT powered off")
 
             if force_nvme_boot:
                 logger.info("[wrapper] Skipping storage.dut() — forcing NVMe boot to fix EFI entries")
                 force_nvme_boot = False
+            else:
+                client.storage.dut()
+                logger.info("[wrapper] Storage connected to DUT")
 
             client.power.on()
-            logger.info("[wrapper] DUT powered on (booting)")
+            logger.info("[wrapper] DUT powered on")
 
             with client.serial.pexpect() as p:
                 p.logfile = sys.stdout.buffer

--- a/tests_suites/conftest.py
+++ b/tests_suites/conftest.py
@@ -353,6 +353,17 @@ def fetch_hardware_logs_session(hardware_info_session):
         fetch_hardware_logs(ssh)
     logger.info("[Teardown] Hardware logs fetched successfully")
 
+@pytest.fixture(scope="class", autouse=True)
+def drop_memory_cache(ssh):
+    """
+    Clear memory (RAM) cache of the Jetson before and after each test class. 
+    to ensure the shared memory is being freed 
+    (with these sharing memory between the system and GPU, going out of memory due to system cache is known to happen)
+    """
+    yield
+    ssh.sudo("sync; sync; sync")
+    ssh.sudo("echo 3 | sudo tee /proc/sys/vm/drop_caches")
+
 @pytest.fixture(scope="class")
 def ssh():
     """


### PR DESCRIPTION
Wrapper: replace power.cycle() with explicit on→dut→off→on sequence so the storage controller is active when attaching storage, preventing boot loops. Also flush stale serial prompts before SSH login to avoid pexpect mismatches.

conftest: add drop_memory_cache fixture that clears RAM caches between test classes. Jetson devices share memory between CPU and GPU — cached pages were exhausting available memory and causing VPI tests to fail with OOM.