### PR TITLE
Fix DLA trtexec test failure by preserving pre-built binary

### DIFF
--- a/tests_suites/dla/Dockerfile.l4t_tensorrt
+++ b/tests_suites/dla/Dockerfile.l4t_tensorrt
@@ -2,5 +2,8 @@ ARG L4T_JETPACK_IMAGE=nvcr.io/nvidia/l4t-jetpack:r36.4.0
 FROM ${L4T_JETPACK_IMAGE}
 # TensorRT (trtexec, samples, models) is pre-installed in L4T container
 # COMPILE ONLY — build TensorRT samples for testing
+# Preserve NVIDIA's pre-built trtexec: recompilation overwrites it with a broken binary
 RUN apt-get update && apt-get install -y make g++
+RUN cp /usr/src/tensorrt/bin/trtexec /usr/src/tensorrt/bin/trtexec.prebuilt
 RUN make -C /usr/src/tensorrt/samples -j $(nproc) || true
+RUN mv /usr/src/tensorrt/bin/trtexec.prebuilt /usr/src/tensorrt/bin/trtexec


### PR DESCRIPTION
Recompiling TensorRT samples overwrites NVIDIA's pre-built trtexec with a version that has broken linker paths on aarch64, causing DLA inference to fail with Internal Error in buildWtsEngine. Backup and restore the pre-built binary around the sample compilation step.