### PR TITLE
Fix Jumpstarter test stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ qe-rhel-jetson/
 │
 ├── jumpstarter/                # Jumpstarter integration for hardware testing
 │   └── wrapper.py              # Flash existing image & test via Jumpstarter framework
+│   └── container_images.yaml   # container images to pre-pull before pytest execution           
 │
 └── .github/workflows/          # CI/CD - IN PROGRESS (Blocked by Firewall issues)
     └── beaker-test.yml         # Reserve Beaker machine, deploy, run tests

--- a/beaker/README.md
+++ b/beaker/README.md
@@ -199,6 +199,34 @@ ansible-playbook -i inventory.yml install_jetpack_rpms.yml \
   -e "target_host=${JETSON_HOST}" --check
 ```
 
+### Optional: Enable Graphical Desktop (GDM)
+
+The base bootc image does not include GDM and defaults to multi-user.target. To enable graphical desktop, you have two options:
+
+1. **Build a GUI container image** using `jumpstarter/Containerfile-gui` (layers GDM + GNOME on top of the base bootc image, sets graphical.target) — then use that image in the podman run command below.
+2. **Use the podman run command below** with a pre-built GUI variant image that already includes GDM.
+
+The graphical.target is only for enabling the desktop environment — it is not the default bootc target.
+
+```bash
+podman run --rm --privileged \
+  -v /dev:/dev \
+  -v /var/lib/containers:/var/lib/containers \
+  -v /:/target \
+  --pid=host \
+  --security-opt label=type:unconfined_t \
+  <gui-variant-image> \
+  /bin/bash -c '
+    bootc install to-existing-root \
+      --root-ssh-authorized-keys=/target/root/.ssh/authorized_keys \
+      --skip-fetch-check
+    systemctl --root=/target enable gdm.service || true
+    systemctl --root=/target set-default graphical.target || true
+  '
+```
+
+The Jetson should boot with a graphical desktop environment (GDM login screen).
+
 ### 6. Run Tests
 
 ```bash

--- a/jumpstarter/Containerfile-gui
+++ b/jumpstarter/Containerfile-gui
@@ -17,10 +17,16 @@ RUN dnf install -y --nogpgcheck \
     gnome-shell \
     gnome-control-center \
     nautilus \
+    xorg-x11-server-Xorg \
     xorg-x11-drivers \
+    rsync \
     x11vnc \
     && dnf clean all
 
-RUN usermod -aG video gdm
+RUN usermod -aG video gdm && \
+    systemctl enable gdm.service && \
+    systemctl set-default graphical.target
 
-RUN systemctl set-default graphical.target
+RUN set -x; kver=$(cd /usr/lib/modules && echo *); \
+    rm -f /usr/lib/modules/$kver/initramfs.img && \
+    dracut -vf /usr/lib/modules/$kver/initramfs.img $kver

--- a/jumpstarter/README.md
+++ b/jumpstarter/README.md
@@ -250,6 +250,8 @@ dnf install --transient -y x11vnc
 
 # 2. Find the actual display number and Xauthority path
 export XDISPLAY=$(cat /proc/$(pgrep -o gnome-shell)/environ | tr '\0' '\n' | grep DISPLAY | cut -d= -f2)
+# or if gnome-shell directory not exists
+export XDISPLAY=$(ls /tmp/.X11-unix/ | sed 's/X/:/') # probebly without gnome-shell directory will fail
 export XAUTH=$(ps aux | grep Xorg | grep -oP '(?<=-auth )\S+')
 
 # 3. Start x11vnc

--- a/jumpstarter/container_images.yaml
+++ b/jumpstarter/container_images.yaml
@@ -1,0 +1,27 @@
+# NGC container images to pre-pull before pytest execution.
+# Pulled in order listed (smallest first). Each gets a fresh SSH connection.
+# ${L4T_JETPACK_IMAGE} is expanded from the environment variable at runtime.
+
+images:
+  - url: "${L4T_JETPACK_IMAGE}"
+    timeout: 900
+    required: true
+    size_hint: "~1.5GB"
+
+  - url: "nvcr.io/nvidia/tensorrt:25.09-py3-igpu"
+    timeout: 2400
+    required: true
+    size_hint: "~3GB"
+
+  - url: "nvcr.io/nvidia/pytorch:25.09-py3-igpu"
+    timeout: 3600
+    required: true
+    size_hint: "~10-15GB"
+
+  - url: "nvcr.io/nvidia/tensorflow:24.04-tf2-py3-igpu"
+    timeout: 3600
+    required: true
+    size_hint: "~10-15GB"
+
+rest_between_pulls: 30
+min_disk_space_mb: 5000

--- a/jumpstarter/wrapper.py
+++ b/jumpstarter/wrapper.py
@@ -5,6 +5,7 @@ import time
 import sys
 import os
 import re
+import yaml
 import subprocess
 from pathlib import Path
 from logging import getLogger
@@ -30,6 +31,115 @@ if PASSWORD is None and KEY_PATH is None:
 key_filename = os.path.expanduser(KEY_PATH) if KEY_PATH else None
 if key_filename and not os.path.exists(key_filename):
     raise ValueError(f"SSH key file not found: {key_filename}")
+
+
+def _expand_env_vars(text):
+    """Expand ${VAR} patterns in text using os.environ."""
+    return re.sub(r'\$\{([^}]+)\}', lambda m: os.environ.get(m.group(1), m.group(0)), text)
+
+
+def _prepull_container_images(addr, username, password, key_filename):
+    """Pre-pull NGC container images listed in container_images.yaml.
+
+    Creates a fresh SSH session for each pull through the active
+    TcpPortforwardAdapter tunnel.  Performs health checks (disk space,
+    memory cache drop) and rest periods between pulls to avoid
+    overloading the device.
+    """
+    if os.environ.get("SKIP_PREPULL", "").strip() in ("1", "true", "yes"):
+        logger.info("[wrapper] SKIP_PREPULL is set, skipping container image pre-pull")
+        return
+
+    config_path = Path(__file__).parent / "container_images.yaml"
+    if not config_path.exists():
+        logger.warning("[wrapper] No container_images.yaml found, skipping pre-pull")
+        return
+
+    try:
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+    except Exception as e:
+        logger.warning("[wrapper] Failed to parse container_images.yaml: %s, skipping pre-pull", e)
+        return
+
+    images = config.get("images", [])
+    rest_period = config.get("rest_between_pulls", 30)
+    min_disk_mb = config.get("min_disk_space_mb", 5000)
+
+    if not images:
+        raise RuntimeError("[wrapper] No images listed in container_images.yaml")
+
+    from infra_tests.ssh_client import SSHConnection
+
+    pulled, cached, failed = [], [], []
+    logger.info("[wrapper] Starting NGC container image pre-pull (%d images)...", len(images))
+
+    for i, img in enumerate(images):
+        url = _expand_env_vars(img["url"])
+        timeout = img.get("timeout", 1800)
+        required = img.get("required", True)
+        size_hint = img.get("size_hint", "unknown size")
+
+        print(f"[wrapper] Pre-pulling image {i + 1}/{len(images)}: {url} ({size_hint}, timeout={timeout}s)...", flush=True)
+        logger.info("[wrapper] Pre-pulling image %d/%d: %s (%s, timeout=%ds)...",
+                    i + 1, len(images), url, size_hint, timeout)
+
+        try:
+            with SSHConnection(addr[0], username, password, addr[1],
+                               key_filename=key_filename) as ssh:
+                # Check disk space on /var (where podman stores images on bootc)
+                result = ssh.sudo("df -m /var | tail -1 | awk '{print $4}'", fail_on_rc=False)
+                try:
+                    avail_mb = int(result.stdout.strip())
+                    logger.info("[wrapper]   Disk space: %dMB available on /var (min: %dMB)", avail_mb, min_disk_mb)
+                    if avail_mb < min_disk_mb:
+                        logger.warning("[wrapper]   Low disk space: %dMB < %dMB — pull may fail", avail_mb, min_disk_mb)
+                except (ValueError, AttributeError):
+                    logger.warning("[wrapper]   Could not parse disk space, continuing anyway")
+
+                # Check if already cached
+                check = ssh.sudo(f"podman image exists {url}", fail_on_rc=False)
+                if check.exit_status == 0:
+                    print(f"[wrapper]   Image already cached, skipping", flush=True)
+                    logger.info("[wrapper]   Image already cached, skipping")
+                    cached.append(url)
+                    continue
+
+                # Drop memory caches before pull
+                logger.info("[wrapper]   Dropping memory caches...")
+                ssh.sudo("sync; sync; sync", fail_on_rc=False)
+                ssh.sudo("echo 3 | tee /proc/sys/vm/drop_caches", fail_on_rc=False)
+
+                # Pull the image
+                start = time.time()
+                ssh.sudo(f"podman pull {url}", timeout=timeout)
+                elapsed = int(time.time() - start)
+                print(f"[wrapper]   Pull complete in {elapsed}s", flush=True)
+                logger.info("[wrapper]   Pull complete in %ds", elapsed)
+                pulled.append(url)
+
+        except Exception as e:
+            if required:
+                raise RuntimeError(f"[wrapper] Required image pull failed ({url}): {e}")
+            logger.warning("[wrapper]   Optional image pull failed: %s: %s", url, e)
+            failed.append(url)
+
+        # Rest between pulls (skip after the last one)
+        if i < len(images) - 1:
+            logger.info("[wrapper]   Resting %ds before next pull...", rest_period)
+            time.sleep(rest_period)
+            # SSH liveness probe
+            try:
+                with SSHConnection(addr[0], username, password, addr[1],
+                                   key_filename=key_filename) as probe:
+                    probe.run("echo alive", timeout=30)
+                logger.info("[wrapper]   SSH liveness check: OK")
+            except Exception:
+                logger.warning("[wrapper]   SSH liveness check failed — tunnel may be degraded")
+
+    print(f"\n[wrapper] Pre-pull complete. Pulled: {len(pulled)}, Cached: {len(cached)}, Failed: {len(failed)}", flush=True)
+    logger.info("[wrapper] Pre-pull complete. Pulled: %d, Cached: %d, Failed: %d",
+                len(pulled), len(cached), len(failed))
 
 
 def _detect_wrong_os(boot_output):
@@ -312,16 +422,31 @@ with env() as client:
 
                     if PASSWORD:
                         logger.info("[wrapper] Configuring SSH root password login via serial console...")
-                        time.sleep(5)
-                        # Flush any stale login prompts from buffer
+                        time.sleep(10)
+                        # Flush any stale output from buffer
                         try:
                             while True:
                                 p.read_nonblocking(size=4096, timeout=1)
                         except Exception:
                             pass
-                        # Send Enter to get a single clean login prompt
+                        # Send Enter and wait for a clean login prompt.
+                        # If the device rebooted after firstboot (SELinux relabel,
+                        # growpart, etc.), the prompt won't appear — wait for the
+                        # second boot to complete.
                         p.sendline("")
-                        p.expect_exact("login:", timeout=30)
+                        try:
+                            p.expect_exact("login:", timeout=60)
+                        except Exception:
+                            logger.info("[wrapper] No login prompt — device may have rebooted (firstboot). Waiting for next boot...")
+                            if not _wait_for_login(p):
+                                raise RuntimeError("[wrapper] Failed to reach login prompt after device reboot")
+                            try:
+                                while True:
+                                    p.read_nonblocking(size=4096, timeout=1)
+                            except Exception:
+                                pass
+                            p.sendline("")
+                            p.expect_exact("login:", timeout=60)
                         p.sendline(USERNAME)
                         p.expect("assword:", timeout=30)
                         p.sendline(PASSWORD)
@@ -380,6 +505,15 @@ with env() as client:
                 key_filename=key_filename,
             ) as ssh:
                 ssh.sudo("/usr/libexec/bootc-generic-growpart")
+
+            os.environ.setdefault("L4T_JETPACK_IMAGE", "nvcr.io/nvidia/l4t-jetpack:r36.4.0")
+            print("\n" + "=" * 80)
+            print("[wrapper] Pre-pulling container images — this may take a while...")
+            print("[wrapper] DO NOT force-exit the wrapper while images are being pulled.")
+            print("[wrapper] To check progress, open another terminal and run:")
+            print("[wrapper] 'jmp shell --lease <LEASE> -- j serial start-console' and then 'pgrep -fa podman'")
+            print("=" * 80 + "\n", flush=True)
+            _prepull_container_images(addr, USERNAME, PASSWORD, key_filename)
 
             logger.info(f"[wrapper] Launching pytest with JETSON_HOST={os.environ['JETSON_HOST']} "
                   f"JETSON_PORT={os.environ['JETSON_PORT']} "

--- a/tests_resources/container_ops.py
+++ b/tests_resources/container_ops.py
@@ -17,9 +17,13 @@ PODMAN_GPU_FLAGS = "--device nvidia.com/gpu=all --group-add keep-groups --securi
 # Configurable L4T image tag
 L4T_JETPACK_IMAGE = os.getenv("L4T_JETPACK_IMAGE", "nvcr.io/nvidia/l4t-jetpack:r36.4.0")
 
+# Default building container image timeout in seconds (30 minutes)
+DEFAULT_BUILD_TIMEOUT = 900
+# Default running container timeout in seconds (10 minutes)
+DEFAULT_RUN_TIMEOUT = 600
 
 def build_container_image(ssh, dockerfile_path, image_tag, context_files=None,
-                          build_args=None, timeout=600, suite_name="test"):
+                          build_args=None, timeout=DEFAULT_BUILD_TIMEOUT, suite_name="test"):
     """
     Build a container image from a Dockerfile on the remote device.
 
@@ -32,7 +36,7 @@ def build_container_image(ssh, dockerfile_path, image_tag, context_files=None,
         image_tag: Tag for the built image (e.g., "l4t-cuda-tests:r36.4.0-v12.9")
         context_files: Optional list of local Path objects to upload alongside Dockerfile
         build_args: Optional dict of build args (e.g., {"CUDA_SAMPLES_VERSION": "v12.9"})
-        timeout: Build timeout in seconds (default 600 = 10 min)
+        timeout: Build timeout in seconds (default is value in seconds of DEFAULT_BUILD_TIMEOUT)
         suite_name: Name prefix for temp dir (e.g., "cuda", "vpi") for easy identification
 
     Returns:
@@ -61,7 +65,7 @@ def build_container_image(ssh, dockerfile_path, image_tag, context_files=None,
     return image_tag
 
 
-def run_container(ssh, image_tag, command="", timeout=600, extra_flags=""):
+def run_container(ssh, image_tag, command="", timeout=DEFAULT_RUN_TIMEOUT, extra_flags=""):
     """
     Run a command in a container image via podman run --rm.
     Applies RHEL-specific GPU flags automatically.

--- a/tests_suites/conftest.py
+++ b/tests_suites/conftest.py
@@ -112,16 +112,12 @@ def _install_beaker_repo(ssh, rhel_version: Optional[str]):
 
     main_rhel_version = str(rhel_version).split(".")[0]
     nightly_base = f"https://download.devel.redhat.com/rhel-{main_rhel_version}/nightly/RHEL-{main_rhel_version}/latest-RHEL-{rhel_version}/compose"
-    cmd_appstream = f"dnf config-manager --add-repo {nightly_base}/AppStream/aarch64/os/"
     cmd_baseos = f"dnf config-manager --add-repo {nightly_base}/BaseOS/aarch64/os/"
-    # sslverify=0: download.devel.redhat.com uses Red Hat internal CA not in bootc trust store
+    cmd_appstream = f"dnf config-manager --add-repo {nightly_base}/AppStream/aarch64/os/"
     cmd_sslverify = (
-        'for f in /etc/yum.repos.d/download.devel.redhat.com_*.repo; do '
-        '[ -f "$f" ] && grep -q "^sslverify" "$f" '
-        '&& sed -i "s/^sslverify.*/sslverify=0/" "$f" '
-        '|| echo "sslverify=0" >> "$f"; done'
+        'for repo in /etc/yum.repos.d/download.devel.redhat.com_*.repo; do '
+        'echo -e "sslverify=0\\ngpgcheck=0" >> "$repo"; done'
     )
-    # --nogpgcheck: bootc images don't ship pre-imported GPG keys
     cmd_epel = f"dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-{main_rhel_version}.noarch.rpm -y"
 
     result = ssh.sudo("dnf repolist")
@@ -131,9 +127,8 @@ def _install_beaker_repo(ssh, rhel_version: Optional[str]):
         logger.info("[Setup] Nightly repos missing, installing for RHEL %s", rhel_version)
         for attempt in range(1, 4):
             try:
-                ssh.sudo(cmd_appstream)
                 ssh.sudo(cmd_baseos)
-                ssh.sudo(cmd_sslverify)
+                ssh.sudo(cmd_appstream)
                 break
             except Exception as e:
                 if attempt < 3:
@@ -141,6 +136,7 @@ def _install_beaker_repo(ssh, rhel_version: Optional[str]):
                     time.sleep(5)
                 else:
                     raise
+    ssh.run(cmd_sslverify)
 
     if "epel" not in repos:
         logger.info("[Setup] EPEL missing, installing for RHEL %s", rhel_version)
@@ -315,7 +311,7 @@ def l4t_image_pulled(hardware_info_session):
         JETSON_TIMEOUT,
         key_filename=key_path,
     ) as ssh:
-        ssh.sudo(f"podman pull {L4T_JETPACK_IMAGE}", timeout=300, fail_on_rc=False)
+        ssh.sudo(f"podman pull {L4T_JETPACK_IMAGE}", timeout=900)
     yield
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests_suites/display/test_basic_display.py
+++ b/tests_suites/display/test_basic_display.py
@@ -92,12 +92,7 @@ class TestDisplay:
             pytest.skip("X11 test not applicable on multi-user.target (no graphical session)")
 
         result = ssh.run("which Xorg || which X", fail_on_rc=False)
-        if result.exit_status != 0:
-            warnings.warn(
-                "Xorg/X11 server is not installed on graphical.target — "
-                "expected in GUI variant (Containerfile-gui)",
-                UserWarning,
-            )
+        assert result.exit_status == 0, f"Xorg/X11 server is not installed on graphical.target: {result.stderr}"
 
     def test_wayland_libs(self, ssh):
         """Test Wayland-related libraries are present (nvidia-jetpack-wayland).

--- a/tests_suites/pva/test_basic_pva.py
+++ b/tests_suites/pva/test_basic_pva.py
@@ -6,6 +6,8 @@ PVA (Programmable Vision Accelerator) / VPI tests for Jetson RPMs.
 """
 import pytest
 import os
+import time
+import logging
 from pathlib import Path
 from tests_suites import conftest as _conftest
 from tests_resources.container_ops import (
@@ -13,11 +15,15 @@ from tests_resources.container_ops import (
     L4T_JETPACK_IMAGE,
 )
 
+logger = logging.getLogger(__name__)
+
 FILE = Path(os.path.realpath(__file__)).parent
 
 
 class TestPVA:
     """Test PVA/VPI functionality on Jetson devices."""
+
+    MAX_RETRIES = 2
 
     @pytest.fixture(scope="class")
     def l4t_vpi_image(self, ssh):
@@ -50,7 +56,9 @@ class TestPVA:
     @pytest.mark.critical
     def test_vpi_all_samples(self, ssh, l4t_vpi_image):
         """Test all VPI samples across all backends via L4T container.
-        Uses CDI device exposure + PVA auth disable."""
+        Uses CDI device exposure + PVA auth disable.
+        Retries up to MAX_RETRIES times — dcf_tracker CUDA backend is flaky due to GPU address-space fragmentation 
+        (VPI 3.x bug,fixed in VPI 4.0.3: https://docs.nvidia.com/vpi/release_notes_4_0_5.html)."""
         spec = _conftest.get_hardware_spec(_conftest.HARDWARE_MODEL_NAME)
         # Disable PVA auth if PVA supported (needed for pva and ofa-pva-vic backends)
         if spec.get("pva", {}).get("supported"):
@@ -65,5 +73,27 @@ class TestPVA:
             skip_backends.extend(["pva", "ofa", "ofa-pva-vic"])
             extra_flags = f"-e SKIP_BACKENDS={','.join(skip_backends)}"
 
-        result = run_container(ssh, l4t_vpi_image, "/opt/run-vpi-tests.sh", timeout=600, extra_flags=extra_flags)
-        assert result.exit_status == 0, f"VPI tests failed (see output above for details): {result.stderr}"
+        last_result = None
+        for attempt in range(1, self.MAX_RETRIES + 2):
+            if attempt > 1:
+                logger.warning(
+                    "VPI test attempt %d/%d — retrying after failure "
+                    "(dcf_tracker CUDA flaky due to GPU address-space fragmentation)",
+                    attempt, self.MAX_RETRIES + 1,
+                )
+                ssh.sudo("sync; sync; sync", fail_on_rc=False)
+                ssh.sudo("echo 3 | tee /proc/sys/vm/drop_caches", fail_on_rc=False)
+                time.sleep(5)
+
+            last_result = run_container(ssh, l4t_vpi_image, "/opt/run-vpi-tests.sh", timeout=600, extra_flags=extra_flags)
+            if last_result.exit_status == 0:
+                if attempt > 1:
+                    logger.info("VPI test passed on attempt %d/%d", attempt, self.MAX_RETRIES + 1)
+                break
+        else:
+            logger.error("VPI test failed after %d attempts", self.MAX_RETRIES + 1)
+
+        assert last_result.exit_status == 0, (
+            f"VPI tests failed after {self.MAX_RETRIES + 1} attempts "
+            f"(see output above for details): {last_result.stderr}"
+        )

--- a/tests_suites/usbs/test_basic_usbs.py
+++ b/tests_suites/usbs/test_basic_usbs.py
@@ -55,7 +55,7 @@ class TestUSBs:
             )
 
             # Get actual lsusb lines for this speed
-            result = ssh.sudo(f"lsusb -t | grep -v Bus | grep {speed}", fail_on_rc=False)
+            result = ssh.sudo(f"lsusb -t | grep -v Bus | grep hub | grep {speed}", fail_on_rc=False)
             assert result.exit_status == 0, f"Failed to find USB with speed {speed}: {result.stderr}"
             lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
 


### PR DESCRIPTION
Fix Jumpstarter test stability: pre-pull NGC images, fix repo setup, and test fixes

Issues found during Jumpstarter (not Beaker) test runs on Orin NX and AGX Orin:

Wrapper pre-pull NGC container images:
- Add container_images.yaml listing 4 NGC base images needed by tests
- Add _prepull_container_images() to wrapper.py — pulls all base images after growpart but before pytest, with fresh SSH sessions per pull, rest periods, disk space checks, and memory cache drops between pulls
- Fixes CUDA/PyTorch/TensorFlow tests timing out during podman build because 10-15GB NGC image pulls exhausted the Jumpstarter SSH tunnel
- Fixes SSH tunnel degradation that caused all subsequent tests to fail with "Error reading SSH protocol banner" after heavy container pulls

Fix repo setup for bootc deployments:
- Fix sslverify command: use ssh.run() instead of ssh.sudo() to avoid shell syntax error when passing for-loop to sudo
- Move sslverify command outside the "repos missing" if-block so it runs unconditionally — fixes SSL cert errors on re-runs where repos already exist but sslverify=0 was never applied
- Simplify sslverify command to append sslverify=0 and gpgcheck=0
- Increase L4T image pre-pull timeout from 300s to 900s in conftest

Fix test issues:
- Fix USB spec test: add grep hub filter to lsusb -t parsing to skip child device lines that don't have the /Xp port count pattern
- Add VPI test retry logic (max 3 attempts) for dcf_tracker CUDA flakiness caused by GPU address-space fragmentation (VPI 3.x bug)
- Fix display test: assert Xorg presence on graphical.target instead of warning

Other Jumpstarter improvements:
- Increase default build timeout from 600s to 900s in container_ops.py
- Fix wrapper boot: increase sleep to 10s, handle firstboot reboot (SELinux relabel / growpart) with retry logic for login prompt
- Fix Containerfile-gui: enable gdm.service alongside graphical.target
- Add GUI enablement docs to beaker/README.md