### PR TITLE
Add RC build validation tests for package and root access security

### DIFF
--- a/tests_suites/conftest.py
+++ b/tests_suites/conftest.py
@@ -67,6 +67,7 @@ BOOTC_AVAILABLE: bool = False
 BOOTC_VERSION: Optional[Union[float, str]] = None  # str if X.Y.Z, float if X.Y
 BOOTC_IMAGE_VERSION: Optional[Union[str]] = None
 BOOTC_IMAGE_URL: Optional[str] = None
+IS_STAGE_BUILD: Optional[bool] = None
 SECURE_BOOT_STATE: Optional[str] = None
 
 if JETSON_KEY_PATH: # key path provided, use key-based authentication
@@ -226,6 +227,7 @@ def hardware_info_session():
     global FIRMWARE_VERSION, FIRMWARE_TYPE
     global HARDWARE_MODEL_NAME, KERNEL_VERSION, CPU_ARCH
     global BOOTC_AVAILABLE, BOOTC_VERSION, BOOTC_IMAGE_URL, BOOTC_IMAGE_VERSION
+    global IS_STAGE_BUILD
     global SECURE_BOOT_STATE
     RHEL_VERSION = info.get("rhel_version")
     L4T_VERSION = info.get("l4t_version")
@@ -240,6 +242,7 @@ def hardware_info_session():
     BOOTC_VERSION = info.get("bootc_version")
     BOOTC_IMAGE_VERSION = info.get("bootc_image_version")
     BOOTC_IMAGE_URL = info.get("bootc_image_url")
+    IS_STAGE_BUILD = "stage" in (BOOTC_IMAGE_URL or "").lower()
     SECURE_BOOT_STATE = info.get("secure_boot_state")
     # Skip entire session if hardware model is not in Testing Matrix (jetson_hardware_specs.yaml)
     if get_hardware_spec(HARDWARE_MODEL_NAME) is None:
@@ -294,6 +297,7 @@ def hardware_info_session():
     print(f"8. Bootc available:          {BOOTC_AVAILABLE}")
     print(f"9. Bootc image version:      {BOOTC_IMAGE_VERSION}")
     print(f"10. Bootc image URL:          {BOOTC_IMAGE_URL}")
+    print(f"11. Stage build:              {IS_STAGE_BUILD}")
     print("=" * 80 + "\n")
     yield
 

--- a/tests_suites/jetson_hardware_specs.yaml
+++ b/tests_suites/jetson_hardware_specs.yaml
@@ -15,7 +15,7 @@ _target_versions:
     rhel_version: "9.8"
     l4t_version: "36.5.0"
     uefi_firmware_version: "36.5.1"
-    kernel_version: "5.14.0-687.5.1"
+    kernel_version: "5.14.0-687.10.1"
 
 # -----------------------------------------------------------------------------
 # Shared templates (anchors for merge; not used as match keys)

--- a/tests_suites/sanity/test_build_validation.py
+++ b/tests_suites/sanity/test_build_validation.py
@@ -1,0 +1,67 @@
+"""
+Build validation tests for RC (production) vs stage bootc images.
+
+RC builds (Containerfile.in) omit stage-only packages and have no root password.
+Stage builds (Containerfile-stage.in) include rsync, xorg-x11-server-Xorg, and
+set a default root password.
+"""
+import pytest
+from tests_suites import conftest
+from logging import getLogger
+logger = getLogger(__name__)
+
+STAGE_ONLY_PACKAGES = ["rsync", "xorg-x11-server-Xorg"]
+
+
+class TestRCBuildPackages:
+    """Verify RC builds do not ship stage-only packages."""
+
+    @pytest.mark.parametrize("package", STAGE_ONLY_PACKAGES)
+    def test_stage_only_package_not_installed(self, ssh, package):
+        """Stage-only packages must not be present on RC/production builds."""
+        if conftest.IS_STAGE_BUILD:
+            pytest.skip("Stage build — expecting stage-only packages to be present")
+
+        result = ssh.run(f"rpm -q {package}", fail_on_rc=False)
+        assert result.exit_status != 0, (
+            f"{package} is installed on an RC build but should only be in stage images"
+        )
+        logger.info(f"[RC validation] {package} correctly absent from RC build")
+
+
+class TestRootAccess:
+    """Verify root access matches build type expectations."""
+
+    def test_ssh_password_auth_disabled(self, ssh):
+        """RC builds must not allow SSH password login for root.
+        Verifies root has no usable password hash in /etc/shadow."""
+        if conftest.IS_STAGE_BUILD:
+            pytest.skip("Stage build sets a default root password")
+
+        result = ssh.run("getent shadow root | cut -d: -f2", fail_on_rc=False)
+        assert result.exit_status == 0, f"Failed to read shadow entry: {result.stderr}"
+
+        password_field = result.stdout.strip()
+        logger.info(f"[RC validation] root password field: {password_field!r}")
+        assert password_field in ("!!", "!", "*", ""), (
+            f"Root has a password hash set ({password_field[:8]}...) — "
+            f"RC builds should not allow password-based SSH login"
+        )
+
+    def test_root_password_locked(self, ssh):
+        """RC builds must have root password locked (key-only access).
+        Stage builds set a default root password."""
+        result = ssh.run("passwd -S root", fail_on_rc=False)
+        assert result.exit_status == 0, f"Failed to query root password status: {result.stderr}"
+
+        status_field = result.stdout.split()[1] if len(result.stdout.split()) > 1 else ""
+        logger.info(f"[RC validation] root password status: {status_field}")
+
+        if conftest.IS_STAGE_BUILD:
+            assert status_field == "PS", (
+                f"Stage build should have root password set (PS), got: {status_field}"
+            )
+        else:
+            assert status_field in ("LK", "NP", "L"), (
+                f"RC build should have root password locked, got: {status_field}"
+            )


### PR DESCRIPTION
1. Add IS_STAGE_BUILD flag to conftest.py — detects stage vs RC builds from the bootc image URL, printed in session header
2. Add test_build_validation.py with 3 test cases:
   - test_stage_only_package_not_installed: verify rsync and xorg-x11-server-Xorg are absent on RC builds (parametrized)
   - test_ssh_password_auth_disabled: verify root has no password hash in /etc/shadow on RC builds (no password-based SSH possible)
   - test_root_password_locked: verify passwd -S shows locked status on RC, or password-set on stage
3. Bump RHEL 9.8 target kernel to 5.14.0-687.10.1