### PR TITLE
Skip registry login when credentials are empty

### DIFF
--- a/beaker/ansible/install_bootc_v3.yml
+++ b/beaker/ansible/install_bootc_v3.yml
@@ -120,8 +120,9 @@
     - name: Login to container registry
       ansible.builtin.command:
         cmd: podman login -u '{{ registry_user }}' -p '{{ registry_pass }}' {{ registry_url }}
-      no_log: true  # Don't log credentials
+      no_log: true
       changed_when: true
+      when: registry_user | default('') | length > 0 and registry_pass | default('') | length > 0
       tags: [registry]
     
     #=========================================================================


### PR DESCRIPTION
Make registry login conditional so the step is skipped when `registry_user`/`registry_pass` are empty.

This allows CI rehearsals and runs without registry credentials to proceed past the login step and attempt the image pull (or fail gracefully there instead of hanging).

The CI step ref already has `REGISTRY_USERNAME`/`REGISTRY_PASSWORD` defaulting to empty — this wires that up in the playbook.