### PR TITLE
Create /etc/ostree dir before writing restore script

### DIFF
--- a/beaker/ansible/install_bootc_v3.yml
+++ b/beaker/ansible/install_bootc_v3.yml
@@ -162,6 +162,14 @@
     # Step 6: Set up boot restoration (restore original EFI order after timer)
     # Note: bootc team fixed boot entry handling; no manual EFI entry creation.
     #=========================================================================
+    - name: Ensure /etc/ostree directory exists
+      ansible.builtin.file:
+        path: /etc/ostree
+        state: directory
+        mode: '0755'
+      when: setup_boot_restore
+      tags: [restore]
+
     - name: Create boot restoration script
       ansible.builtin.copy:
         dest: /etc/ostree/restore_boot.sh


### PR DESCRIPTION
The /etc/ostree directory does not exist on RHEL 9.8 before first bootc reboot. Create it explicitly before writing the restore script.