### PR TITLE
Unmount /boot before bootc install to handle leftover mounts

### DIFF
--- a/beaker/ansible/install_bootc_v3.yml
+++ b/beaker/ansible/install_bootc_v3.yml
@@ -138,6 +138,13 @@
     #=========================================================================
     # Step 5: Run bootc install to-existing-root
     #=========================================================================
+    - name: Unmount /boot if already mounted (leftover from previous run)
+      ansible.builtin.command:
+        cmd: umount /boot
+      failed_when: false
+      changed_when: false
+      tags: [install]
+
     - name: Run bootc install to-existing-root
       ansible.builtin.command:
         cmd: >


### PR DESCRIPTION
If a previous CI run installed bootc but timed out before rebooting, /boot stays mounted. Bootc then fails on the next run with 'already mounted'. Unmount it first (with `failed_when: false` so it's a no-op when not mounted).