### PR TITLE
Unmount /boot/efi before /boot to fix bootc install mount error

### DIFF
--- a/beaker/ansible/install_bootc_v3.yml
+++ b/beaker/ansible/install_bootc_v3.yml
@@ -138,9 +138,16 @@
     #=========================================================================
     # Step 5: Run bootc install to-existing-root
     #=========================================================================
+    - name: Unmount /boot/efi if mounted (must unmount before /boot)
+      ansible.builtin.command:
+        cmd: umount -l /boot/efi
+      failed_when: false
+      changed_when: false
+      tags: [install]
+
     - name: Unmount /boot if already mounted (leftover from previous run)
       ansible.builtin.command:
-        cmd: umount /boot
+        cmd: umount -l /boot
       failed_when: false
       changed_when: false
       tags: [install]


### PR DESCRIPTION
/boot/efi (vfat) is submounted under /boot. Regular umount fails with 'target is busy' because of the submount. Use umount -l on both, efi first, then boot.